### PR TITLE
Features refactor2

### DIFF
--- a/public/Architecture/01-architecture-map.html
+++ b/public/Architecture/01-architecture-map.html
@@ -127,7 +127,7 @@
     const info = {
       frontend: {
         title: "sendly-frontend",
-        body: "Client-side wallet management & transaction construction. Direct Circle Gateway & Bridge integration for instant fiat and cross-chain operations.",
+        body: "UI, Internal vs Browser wallet toggle, tx building, Gateway and Bridge in the client.",
         paths: [
           "src/lib/circle/developerWalletService.ts",
           "src/lib/circle/gateway/*",
@@ -137,7 +137,7 @@
       },
       supabase: {
         title: "sendly-supabase",
-        body: "Edge-powered orchestration: Wallet management, smart contract execution, and Unified Balance Kit for seamless multi-chain operations.",
+        body: "API keys and entity secret never leave the Edge layer. Wallets, contractExecution, Gateway UBK.",
         paths: [
           "functions/arc/server/index.tsx - /wallets/*",
           "functions/arc/server/gateway-*/",

--- a/public/giftcard.html
+++ b/public/giftcard.html
@@ -14,12 +14,12 @@
 
         <main class="main-content">
             <div class="content-left">
-                <div class="section-label">GIFT CARD</div>
-                <h1 class="main-heading">Redeem on-chain Gift Card and cash out to USD</h1>
+                <div class="section-label">DEMO ONLY</div>
+                <h1 class="main-heading">Redeem on-chain Gift Card and simulate USD cash out</h1>
                 <p class="description">
-                    This demo calls the Gift Card smart contract on Arc Testnet to redeem
-                    a card, then simulates USD off-ramp via Circle Mint Playground.
-                    Use a funded test card and an Arc Developer/EVM wallet.
+                    This page is a non-production Arc Testnet demo. It calls the Gift Card
+                    smart contract and simulates a USD off-ramp with demo bank accounts.
+                    Do not use this page as a production cash-out flow.
                 </p>
                 <p class="description" style="margin-top:12px">
                     Contract: <a href="https://testnet.arcscan.app/address/0x5743fd9c6372bE37B2CE8884EA9e8bF291132677" target="_blank" rel="noopener">

--- a/public/giftcard.js
+++ b/public/giftcard.js
@@ -7,6 +7,9 @@ const contractAddressInput = document.getElementById('contractAddress');
 const redeemAmountInput = document.getElementById('redeemAmount');
 const bankAccountSelect = document.getElementById('bankAccount');
 
+// Demo-only helper for the Arc Testnet Circle Mint route. Production cash-out
+// must use a backend-controlled off-ramp flow with real KYC/account checks.
+
 let provider;
 let signer;
 

--- a/src/components/ClaimTwitchCards.tsx
+++ b/src/components/ClaimTwitchCards.tsx
@@ -524,7 +524,3 @@ export function ClaimTwitchCards() {
     </div>
   );
 }
-
-
-
-

--- a/src/components/CreateGiftCard.tsx
+++ b/src/components/CreateGiftCard.tsx
@@ -18,180 +18,33 @@ import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { toast } from 'sonner';
 import { useAccount, useWalletClient } from 'wagmi';
-import { createWalletClient, custom, createPublicClient, http } from 'viem';
-import web3Service from '@/lib/web3/web3Service';
 import { arcTestnet, tempoTestnet } from '@/lib/web3/wagmiConfig';
-import { ERC20ABI, getExplorerTxUrl, getContractsForChain, ARC_CHAIN_ID } from '@/lib/web3/constants';
+import { getExplorerTxUrl, getContractsForChain, ARC_CHAIN_ID } from '@/lib/web3/constants';
 import { generateNewIpfsUri } from '@/lib/newIpfsUri';
-// import { insertFakeUri } from '@/lib/supabase/uriService';
-import { createTwitterCardMapping } from '@/lib/twitter';
-import { createTwitchCardMapping } from '@/lib/twitch';
-import { createTelegramCardMapping } from '@/lib/telegram';
-import { createTikTokCardMapping } from '@/lib/tiktok';
-import { createInstagramCardMapping } from '@/lib/instagram';
 import BridgeDialog from '@/components/BridgeDialog';
-import { GiftCardsService } from '@/lib/supabase/giftCards';
 import { useNavigate } from 'react-router-dom';
 import { generateBridgeUrlFromArc } from '@/lib/bridge/bridgeUrlHelper';
 import { usePrivySafe } from '@/lib/privy/usePrivySafe';
-import { DeveloperWalletService } from '@/lib/circle/developerWalletService';
-import { apiCall } from '@/lib/supabase/client';
-
-interface GiftCardData {
-  recipientType: 'address' | 'twitter' | 'twitch' | 'telegram' | 'tiktok' | 'instagram';
-  recipientAddress: string;
-  recipientUsername: string;
-  amount: string;
-  currency: 'USDC' | 'EURC' | 'PATHUSD' | 'ALPHAUSD' | 'BETAUSD' | 'THETAUSD';
-  design: 'pink' | 'blue' | 'green' | 'custom';
-  message: string;
-  secretMessage: string;
-  hasTimer: boolean;
-  timerHours: number;
-  hasPassword: boolean;
-  password: string;
-  expiryDays: number;
-  customImage: string;
-  nftCover: string;
-}
-
-type PlatformIcon = 'wallet' | 'twitter' | 'twitch' | 'telegram' | 'tiktok' | 'instagram';
-
-const RECIPIENT_OPTIONS: Array<{
-  value: 'address' | 'twitter' | 'twitch' | 'telegram' | 'tiktok' | 'instagram';
-  label: string;
-  icon: PlatformIcon;
-}> = [
-  { value: 'address', label: 'Wallet address', icon: 'wallet' },
-  { value: 'twitter', label: 'Twitter', icon: 'twitter' },
-  { value: 'twitch', label: 'Twitch', icon: 'twitch' },
-  { value: 'telegram', label: 'Telegram', icon: 'telegram' },
-  { value: 'tiktok', label: 'TikTok', icon: 'tiktok' },
-  { value: 'instagram', label: 'Instagram', icon: 'instagram' }
-];
-
-// Helper function to render platform icons
-const renderPlatformIcon = (platform: PlatformIcon, className: string = "w-4 h-4") => {
-  switch (platform) {
-    case 'wallet':
-      return <Wallet className={className} />;
-    case 'twitter':
-      return (
-        <svg className={className} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
-        </svg>
-      );
-    case 'twitch':
-      return (
-        <svg className={className} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-          <path d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0L1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143l-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714Z"/>
-        </svg>
-      );
-    case 'telegram':
-      return (
-        <svg className={className} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-          <path d="M9.50039 15.0005L9.30305 18.7916C9.63343 18.7916 9.77653 18.6502 9.94861 18.4803L11.4982 16.9898L15.251 19.7367C15.9373 20.1197 16.4205 19.9285 16.6027 19.0304L18.9395 7.42573L18.9402 7.42504C19.1555 6.32428 18.5201 5.86444 17.851 6.13415L4.90234 11.1053C3.84037 11.5206 3.85629 12.1181 4.7964 12.3878L8.10118 13.3485L15.8533 8.52547C16.2199 8.28796 16.5538 8.42039 16.2799 8.6579L9.50039 15.0005Z" />
-        </svg>
-      );
-    case 'tiktok':
-      return (
-        <svg className={className} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-          <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z"/>
-        </svg>
-      );
-    case 'instagram':
-      return (
-        <svg className={className} viewBox="0 0 512 512" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-          <path d="M349.33 69.33a93.62 93.62 0 0193.34 93.34v186.66a93.62 93.62 0 01-93.34 93.34H162.67a93.62 93.62 0 01-93.34-93.34V162.67a93.62 93.62 0 0193.34-93.34h186.66m0-37.33H162.67C90.8 32 32 90.8 32 162.67v186.66C32 421.2 90.8 480 162.67 480h186.66C421.2 480 480 421.2 480 349.33V162.67C480 90.8 421.2 32 349.33 32z"/>
-          <path d="M377.33 162.67a28 28 0 1128-28 27.94 27.94 0 01-28 28zM256 181.33A74.67 74.67 0 11181.33 256 74.75 74.75 0 01256 181.33m0-37.33a112 112 0 10112 112 112 112 0 00-112-112z"/>
-        </svg>
-      );
-    default:
-      return null;
-  }
-};
-
-// Helper function to detect wallet name
-function getWalletName(): string {
-  if (typeof window === 'undefined' || !window.ethereum) {
-    return 'Web3 Wallet';
-  }
-
-  const ethereum = window.ethereum as any;
-
-  // IMPORTANT: Check Rabby BEFORE MetaMask, but verify it's actually Rabby
-  // Rabby is based on MetaMask, so it may have isMetaMask = true
-  // But if ONLY isMetaMask is true (without isRabby), it's MetaMask
-  if (ethereum.isRabby === true) {
-    // Double-check: Rabby should have isRabby explicitly set to true
-    return 'Rabby Wallet';
-  }
-  
-  // If isMetaMask is true but isRabby is not explicitly true, it's MetaMask
-  if (ethereum.isMetaMask === true && ethereum.isRabby !== true) {
-    return 'MetaMask';
-  }
-  
-  // Fallback: if isMetaMask is true (even if isRabby might be undefined)
-  if (ethereum.isMetaMask === true) {
-    return 'MetaMask';
-  }
-  if (ethereum.isCoinbaseWallet) {
-    return 'Coinbase Wallet';
-  }
-  if (ethereum.isTrust) {
-    return 'Trust Wallet';
-  }
-  if (ethereum.isBraveWallet) {
-    return 'Brave Wallet';
-  }
-  if (ethereum.isTokenPocket) {
-    return 'TokenPocket';
-  }
-  if (ethereum.isImToken) {
-    return 'imToken';
-  }
-  if (ethereum.isOKExWallet) {
-    return 'OKX Wallet';
-  }
-  if (ethereum.isBitKeep) {
-    return 'BitKeep';
-  }
-  if (ethereum.isFrame) {
-    return 'Frame';
-  }
-  if (ethereum.isPhantom) {
-    return 'Phantom';
-  }
-  if (ethereum.isAvalanche) {
-    return 'Avalanche Wallet';
-  }
-  if (ethereum.isZeppelin) {
-    return 'Zeppelin';
-  }
-  
-  // Check for Rainbow Wallet (via RainbowKit)
-  if (ethereum.isRainbow) {
-    return 'Rainbow Wallet';
-  }
-  
-  // Check provider name if available (some wallets set this)
-  // But be careful - only use this if we haven't identified the wallet yet
-  // and only if it's an exact match
-  if (ethereum.providerName && !ethereum.isMetaMask && !ethereum.isRabby) {
-    const providerName = String(ethereum.providerName).toLowerCase().trim();
-    // Only trust exact matches
-    if (providerName === 'rabby' || providerName === 'rabby wallet') {
-      return 'Rabby Wallet';
-    }
-    if (providerName === 'metamask') {
-      return 'MetaMask';
-    }
-  }
-
-  // Default fallback
-  return 'Web3 Wallet';
-}
+import { PlatformIcon } from '@/components/gift-card/PlatformIcon';
+import { RECIPIENT_OPTIONS } from '@/components/gift-card/recipientOptions';
+import { DEFAULT_WALLET_NAME, detectWalletName } from '@/components/gift-card/walletName';
+import { parseSelectedGiftCardRecipient } from '@/components/gift-card/selectedRecipient';
+import type { GiftCardData } from '@/components/gift-card/types';
+import { useDeveloperWalletLookup } from '@/components/gift-card/useDeveloperWalletLookup';
+import {
+  INITIAL_GIFT_CARD_DATA,
+  RESET_GIFT_CARD_DATA,
+  buildCreatedCardData,
+  classifyCreateGiftCardError,
+  createGiftCardWithConnectedWallet,
+  createGiftCardWithDeveloperWallet,
+  extractTxHashFromError,
+  getTokenAddress,
+  resolveCreateWallet,
+  saveCreatedGiftCard,
+  toTokenUnits,
+  validateGiftCardRequest
+} from '@/components/gift-card/giftCardFlow';
 
 export function CreateGiftCard() {
   const { address, isConnected, connector } = useAccount();
@@ -205,29 +58,21 @@ export function CreateGiftCard() {
     ? (['PATHUSD', 'ALPHAUSD', 'BETAUSD', 'THETAUSD'] as const)
     : (['USDC', 'EURC'] as const);
   const { authenticated, user: privyUser } = usePrivySafe();
-  const [walletName, setWalletName] = useState<string>('Web3 Wallet');
+  const [walletName, setWalletName] = useState<string>(DEFAULT_WALLET_NAME);
   const navigate = useNavigate();
-  const [hasDeveloperWallet, setHasDeveloperWallet] = useState(false);
-  const [developerWallet, setDeveloperWallet] = useState<any>(null);
-  const [checkingWallet, setCheckingWallet] = useState(true);
-  const [walletSource, setWalletSource] = useState<'metamask' | 'developer'>('metamask');
-  const [formData, setFormData] = useState<GiftCardData>({
-    recipientType: 'address',
-    recipientAddress: '',
-    recipientUsername: '',
-    amount: '1',
-    currency: 'USDC',
-    design: 'pink',
-    message: '',
-    secretMessage: '',
-    hasTimer: false,
-    timerHours: 24,
-    hasPassword: false,
-    password: '',
-    expiryDays: 365,
-    customImage: '',
-    nftCover: ''
+  const {
+    hasDeveloperWallet,
+    developerWallet,
+    checkingWallet,
+    walletSource,
+    setWalletSource
+  } = useDeveloperWalletLookup({
+    isConnected,
+    authenticated,
+    address,
+    privyUser
   });
+  const [formData, setFormData] = useState<GiftCardData>(INITIAL_GIFT_CARD_DATA);
 
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
@@ -238,80 +83,32 @@ export function CreateGiftCard() {
   const [isBridgeDialogOpen, setIsBridgeDialogOpen] = useState(false);
   const [highlightField, setHighlightField] = useState<'twitch' | 'twitter' | 'telegram' | 'tiktok' | 'instagram' | null>(null);
 
-  // Load selected recipient from localStorage on mount
   useEffect(() => {
     const selectedRecipient = localStorage.getItem('selectedGiftCardRecipient');
-    if (selectedRecipient) {
-      try {
-        const recipient = JSON.parse(selectedRecipient);
-        if (recipient.type === 'twitch' && recipient.username) {
-          setFormData(prev => ({
-            ...prev,
-            recipientType: 'twitch',
-            recipientUsername: recipient.username
-          }));
-          // Highlight the field
-          setHighlightField('twitch');
-          toast.success(`Selected ${recipient.displayName || recipient.username} for gift card`);
-          // Clear the stored recipient after using it
-          localStorage.removeItem('selectedGiftCardRecipient');
-          // Remove highlight after animation
-          setTimeout(() => setHighlightField(null), 2000);
-        } else if (recipient.type === 'twitter' && recipient.username) {
-          setFormData(prev => ({
-            ...prev,
-            recipientType: 'twitter',
-            recipientUsername: recipient.username
-          }));
-          // Highlight the field
-          setHighlightField('twitter');
-          toast.success(`Selected ${recipient.displayName || recipient.username} for gift card`);
-          localStorage.removeItem('selectedGiftCardRecipient');
-          // Remove highlight after animation
-          setTimeout(() => setHighlightField(null), 2000);
-        } else if (recipient.type === 'telegram' && recipient.username) {
-          setFormData(prev => ({
-            ...prev,
-            recipientType: 'telegram',
-            recipientUsername: recipient.username.replace(/^@/, '')
-          }));
-          setHighlightField('telegram');
-          toast.success(`Selected ${recipient.displayName || recipient.username} for gift card`);
-          localStorage.removeItem('selectedGiftCardRecipient');
-          setTimeout(() => setHighlightField(null), 2000);
-        } else if (recipient.type === 'tiktok' && recipient.username) {
-          setFormData(prev => ({
-            ...prev,
-            recipientType: 'tiktok',
-            recipientUsername: recipient.username.replace(/^@/, '')
-          }));
-          setHighlightField('tiktok');
-          toast.success(`Selected ${recipient.displayName || recipient.username} for gift card`);
-          localStorage.removeItem('selectedGiftCardRecipient');
-          setTimeout(() => setHighlightField(null), 2000);
-        } else if (recipient.type === 'instagram' && recipient.username) {
-          setFormData(prev => ({
-            ...prev,
-            recipientType: 'instagram',
-            recipientUsername: recipient.username.replace(/^@/, '')
-          }));
-          setHighlightField('instagram');
-          toast.success(`Selected ${recipient.displayName || recipient.username} for gift card`);
-          localStorage.removeItem('selectedGiftCardRecipient');
-          setTimeout(() => setHighlightField(null), 2000);
-        } else if (recipient.type === 'address' && recipient.address) {
-          setFormData(prev => ({
-            ...prev,
-            recipientType: 'address',
-            recipientAddress: recipient.address
-          }));
-          toast.success(`Selected ${recipient.displayName || recipient.address.slice(0, 6) + '...' + recipient.address.slice(-4)} for gift card`);
-          localStorage.removeItem('selectedGiftCardRecipient');
-        }
-      } catch (error) {
-        console.error('Error parsing selected recipient:', error);
-        localStorage.removeItem('selectedGiftCardRecipient');
+    if (!selectedRecipient) {
+      return;
+    }
+
+    try {
+      const recipient = parseSelectedGiftCardRecipient(selectedRecipient);
+      if (!recipient) {
+        return;
       }
+
+      setFormData(prev => ({
+        ...prev,
+        ...recipient.patch
+      }));
+      setHighlightField(recipient.highlightField);
+      toast.success(`Selected ${recipient.toastLabel} for gift card`);
+
+      if (recipient.highlightField) {
+        setTimeout(() => setHighlightField(null), 2000);
+      }
+    } catch (error) {
+      console.error('Error parsing selected recipient:', error);
+    } finally {
+      localStorage.removeItem('selectedGiftCardRecipient');
     }
   }, []);
 
@@ -331,233 +128,37 @@ export function CreateGiftCard() {
     });
   }, [isTempoNetwork]);
 
-
-  // Checking for the presence of a Internal Wallet for social networks
-  useEffect(() => {
-    const checkSocialWallet = async () => {
-      // If MetaMask is connected, ALWAYS check for developer wallet by address
-      // This allows finding wallets created with user_id = MetaMask address
-      // Even if user is not authenticated via Privy
-      if (!isConnected && (!authenticated || !privyUser)) {
-        setHasDeveloperWallet(false);
-        setDeveloperWallet(null);
-        setCheckingWallet(false);
-        return;
-      }
-
-      try {
-        setCheckingWallet(true);
-        // Check for a Internal Wallet for linked social networks
-        const socialPlatforms = ['twitter', 'twitch', 'telegram', 'tiktok', 'instagram'];
-        const blockchain = 'ARC-TESTNET';
-        let foundWallet: any = null;
-        
-        // If MetaMask is connected, first try to find wallet by MetaMask address
-        // (Developer Wallet can be created with user_id = MetaMask address)
-        if (isConnected && address) {
-          const normalizedAddress = address.toLowerCase().trim();
-          try {
-            const wallets = await DeveloperWalletService.getWallets(normalizedAddress);
-            
-            // Find wallet for ARC-TESTNET blockchain
-            foundWallet = wallets.find((w: any) => w.blockchain === blockchain) || wallets[0] || null;
-          } catch (error) {
-            // Error fetching wallets by MetaMask address
-          }
-        }
-        
-        // If no wallet found by MetaMask address, try to find by social platforms
-        if (!foundWallet && privyUser) {
-          for (const platform of socialPlatforms) {
-            let socialUserId: string | null = null;
-            
-            if (platform === 'twitter' && privyUser.twitter) {
-              socialUserId = (privyUser.twitter as any).subject;
-            } else if (platform === 'twitch' && privyUser.twitch) {
-              socialUserId = (privyUser.twitch as any).subject;
-            } else if (platform === 'telegram' && privyUser.telegram) {
-              socialUserId = privyUser.telegram.telegramUserId || (privyUser.telegram as any).subject;
-            } else if (platform === 'tiktok' && privyUser.tiktok) {
-              socialUserId = (privyUser.tiktok as any).subject;
-            } else if (platform === 'instagram' && (privyUser as any).instagram) {
-              socialUserId = ((privyUser as any).instagram as any).subject;
-            }
-
-            if (socialUserId) {
-              const wallet = await DeveloperWalletService.getWalletBySocial(
-                platform as 'twitter' | 'twitch' | 'telegram' | 'tiktok' | 'instagram',
-                socialUserId,
-                blockchain
-              );
-              
-              if (wallet) {
-                foundWallet = wallet;
-                break;
-              }
-            }
-          }
-        }
-        
-        // If no wallet found by social platforms, try to find by Privy User ID
-        if (!foundWallet && privyUser?.id) {
-          try {
-            // Normalize Privy User ID (remove 'did:privy:' prefix if present)
-            const normalizedPrivyUserId = privyUser.id.startsWith('did:privy:') 
-              ? privyUser.id.replace('did:privy:', '') 
-              : privyUser.id;
-            
-            const wallets = await DeveloperWalletService.getWallets(normalizedPrivyUserId);
-            
-            // Find wallet for ARC-TESTNET blockchain
-            foundWallet = wallets.find((w: any) => w.blockchain === blockchain) || wallets[0] || null;
-          } catch (error) {
-            // Error fetching wallets by Privy User ID
-          }
-        }
-        
-        // Update state based on found wallet
-        if (foundWallet) {
-          setHasDeveloperWallet(true);
-          setDeveloperWallet(foundWallet);
-          // If MetaMask is also connected, default to MetaMask but allow choice
-          if (isConnected) {
-            setWalletSource('metamask');
-          } else {
-            setWalletSource('developer');
-          }
-        } else {
-          setHasDeveloperWallet(false);
-          setDeveloperWallet(null);
-          // If no developer wallet found and MetaMask is connected, use MetaMask
-          if (isConnected) {
-            setWalletSource('metamask');
-          }
-        }
-      } catch (error) {
-        console.error('Error checking social wallet:', error);
-        setHasDeveloperWallet(false);
-        setDeveloperWallet(null);
-        if (isConnected) {
-          setWalletSource('metamask');
-        }
-      } finally {
-        setCheckingWallet(false);
-      }
-    };
-
-    checkSocialWallet();
-  }, [isConnected, authenticated, privyUser]);
-
-  // Detect wallet name when connected
   useEffect(() => {
     if (isConnected && typeof window !== 'undefined' && window.ethereum) {
-      // First, try to use connector name from wagmi (most reliable)
-      let detectedName = 'Web3 Wallet';
-      
-      if (connector?.name) {
-        const connectorName = connector.name.toLowerCase();
-        if (connectorName.includes('rabby')) {
-          detectedName = 'Rabby Wallet';
-        } else if (connectorName.includes('metamask')) {
-          detectedName = 'MetaMask';
-        } else if (connectorName.includes('coinbase')) {
-          detectedName = 'Coinbase Wallet';
-        } else if (connectorName.includes('trust')) {
-          detectedName = 'Trust Wallet';
-        } else if (connectorName.includes('rainbow')) {
-          detectedName = 'Rainbow Wallet';
-        } else {
-          // Use connector name as-is if it's a known format
-          detectedName = connector.name;
-        }
-      } else {
-        // Fallback to ethereum properties if connector name is not available
-        detectedName = getWalletName();
-      }
-      
-      setWalletName(detectedName);
+      setWalletName(detectWalletName(connector?.name));
     } else {
-      setWalletName('Web3 Wallet');
+      setWalletName(DEFAULT_WALLET_NAME);
     }
   }, [isConnected, connector]);
 
   const handleCreateCard = async () => {
-    // Check for a wallet (MetaMask or Internal Wallet)
-    if (!isConnected && !hasDeveloperWallet) {
-      setError('Please connect your wallet first');
+    const walletResolution = resolveCreateWallet({
+      walletSource,
+      isConnected,
+      address,
+      hasDeveloperWallet,
+      developerWallet
+    });
+
+    if ('error' in walletResolution) {
+      setError(walletResolution.error);
       return;
     }
-    
-    // Determine the wallet address to create the card from based on selected source
-    let createAddress: string;
-    let useDeveloperWallet = false;
-    
-    if (walletSource === 'developer' && hasDeveloperWallet && developerWallet) {
-      // Use Developer wallet
-      createAddress = developerWallet.wallet_address;
-      useDeveloperWallet = true;
-    } else if (walletSource === 'metamask' && isConnected && address) {
-      // Use MetaMask
-      createAddress = address;
-      useDeveloperWallet = false;
-    } else if (isConnected && address) {
-      // Fallback to MetaMask if available
-      createAddress = address;
-      useDeveloperWallet = false;
-    } else if (hasDeveloperWallet && developerWallet) {
-      // Fallback to Developer wallet if available
-      createAddress = developerWallet.wallet_address;
-      useDeveloperWallet = true;
-    } else {
-      setError('Wallet not connected');
+
+    const validationError = validateGiftCardRequest(formData, contracts.contractAddress);
+    if (validationError) {
+      setError(validationError);
       return;
     }
-    
+
+    const { createAddress, useDeveloperWallet } = walletResolution;
     if (!createAddress) {
       setError('Wallet address not found');
-      return;
-    }
-
-    if (!contracts.contractAddress) {
-      setError('GiftCard contract is not configured for this network. Set VITE_AVAX_CONTRACT_ADDRESS in .env.');
-      return;
-    }
-
-    // Validate based on recipient type
-    if (formData.recipientType === 'address') {
-      if (!formData.recipientAddress || !formData.recipientAddress.startsWith('0x')) {
-        setError('Please enter a valid recipient address');
-        return;
-      }
-    } else if (formData.recipientType === 'twitter') {
-      if (!formData.recipientUsername || formData.recipientUsername.trim() === '') {
-        setError('Please enter a Twitter username');
-        return;
-      }
-    } else if (formData.recipientType === 'twitch') {
-      if (!formData.recipientUsername || formData.recipientUsername.trim() === '') {
-        setError('Please enter a Twitch username');
-        return;
-      }
-    } else if (formData.recipientType === 'telegram') {
-      if (!formData.recipientUsername || formData.recipientUsername.trim() === '') {
-        setError('Please enter a Telegram username');
-        return;
-      }
-    } else if (formData.recipientType === 'tiktok') {
-      if (!formData.recipientUsername || formData.recipientUsername.trim() === '') {
-        setError('Please enter a TikTok username');
-        return;
-      }
-    } else if (formData.recipientType === 'instagram') {
-      if (!formData.recipientUsername || formData.recipientUsername.trim() === '') {
-        setError('Please enter an Instagram username');
-        return;
-      }
-    }
-    
-    if (!formData.amount || parseFloat(formData.amount) <= 0) {
-      setError('Please enter a valid amount');
       return;
     }
 
@@ -566,728 +167,93 @@ export function CreateGiftCard() {
     setErrorTxHash(null);
 
     try {
-      // Step 1: Generate fake IPFS URI (без Pinata)
       setStep('uploading');
       toast.info('Preparing metadata...');
-      
       const metadataUri = generateNewIpfsUri();
+      const tokenAddress = getTokenAddress(formData.currency, contracts);
+      const amountWei = toTokenUnits(formData.amount);
 
-      // Step 2: Check token balance and prepare for creation
-      const tokenAddress =
-        formData.currency === 'USDC'
-          ? contracts.usdc
-          : formData.currency === 'EURC'
-            ? (contracts.eurc ?? contracts.usdc)
-            : formData.currency === 'PATHUSD'
-              ? (contracts.pathusd ?? contracts.usdc)
-              : formData.currency === 'ALPHAUSD'
-                ? (contracts.alphausd ?? contracts.usdc)
-                : formData.currency === 'BETAUSD'
-                  ? (contracts.betausd ?? contracts.usdc)
-                  : (contracts.thetausd ?? contracts.usdc);
-      
-      const amountWei = (parseFloat(formData.amount) * 1000000).toString(); // 6 decimals for USDC/EURC
-      
-      // Check balance for Internal Wallet
-      if (useDeveloperWallet) {
-        const publicClient = createPublicClient({
-          chain: activeChain,
-          transport: http()
-        });
-        
-        const balance = await publicClient.readContract({
-          address: tokenAddress as `0x${string}`,
-          abi: ERC20ABI,
-          functionName: 'balanceOf',
-          args: [createAddress as `0x${string}`]
-        }) as bigint;
-        
-        const balanceFormatted = (Number(balance) / 1000000).toFixed(6);
-        
-        if (BigInt(balance) < BigInt(amountWei)) {
-          const errorMsg = `Insufficient ${formData.currency} balance. You have ${balanceFormatted} ${formData.currency}, but need ${formData.amount} ${formData.currency}. Wallet: ${createAddress?.slice(0, 6)}...${createAddress?.slice(-4)}`;
-          setError(errorMsg);
-          setIsCreating(false);
-          return;
-        }
-
-        // check allowance if need make approve
-        // For social usernames, the card creation functions are in the main CONTRACT_ADDRESS, not in vault contracts
-        // Vault contracts are only used for storing cards, not for creating them
-        // For address recipients, also use CONTRACT_ADDRESS
-        const spenderAddress = contracts.contractAddress!;
-
-        const currentAllowance = await publicClient.readContract({
-          address: tokenAddress as `0x${string}`,
-          abi: ERC20ABI,
-          functionName: 'allowance',
-          args: [createAddress as `0x${string}`, spenderAddress as `0x${string}`]
-        }) as bigint;
-
-        if (currentAllowance < BigInt(amountWei)) {
-          toast.info(`Approving ${formData.currency} for contract...`);
-
-        // Determine privyUserId - if wallet was created with user_id = MetaMask address (and no privy_user_id),
-        // use MetaMask address instead of Privy ID for verification
-        let privyUserIdForTx: string | undefined = undefined;
-        
-        // Check if wallet was created with user_id = address (no privy_user_id in DB)
-        const walletCreatedWithAddress = developerWallet && 
-          developerWallet.user_id && 
-          developerWallet.user_id.startsWith('0x') && 
-          !developerWallet.privy_user_id &&
-          isConnected && 
-          address &&
-          developerWallet.user_id.toLowerCase() === address.toLowerCase();
-        
-        if (walletCreatedWithAddress) {
-          // Wallet was created with user_id = MetaMask address, use address for verification
-          privyUserIdForTx = address.toLowerCase();
-        } else if (privyUser?.id) {
-          // Use Privy ID as normal
-          privyUserIdForTx = privyUser.id.startsWith('did:privy:') 
-            ? privyUser.id.replace('did:privy:', '') 
-            : privyUser.id;
-        } else if (isConnected && address) {
-          // If no Privy auth but MetaMask is connected, use MetaMask address
-          privyUserIdForTx = address.toLowerCase();
-        }
-        // Note: If user is authenticated only via social account (no MetaMask),
-        // privyUserId may be undefined, but socialPlatform/socialUserId will be used for verification
-
-          // Send approve via Internal Wallet
-          const approveTx = await DeveloperWalletService.sendTransaction({
-            walletId: developerWallet.circle_wallet_id,
-            walletAddress: developerWallet.wallet_address,
-            contractAddress: tokenAddress,
-            functionName: 'approve',
-            args: [spenderAddress, BigInt(amountWei)],
-            blockchain: 'ARC-TESTNET',
-            privyUserId: privyUserIdForTx,
-            socialPlatform: developerWallet.social_platform || undefined,
-            socialUserId: developerWallet.social_user_id || undefined
-          });
-
-          if (!approveTx.success) {
-            throw new Error(approveTx.error || 'Approve failed');
-          }
-
-          // Wait for approve confirmation (by transactionId)
-          if (approveTx.transactionId) {
-            const maxAttemptsApprove = 30;
-            const pollIntervalApprove = 1000;
-            for (let attempt = 0; attempt < maxAttemptsApprove; attempt++) {
-              await new Promise(resolve => setTimeout(resolve, pollIntervalApprove));
-              try {
-                const approveStatus = await apiCall(`/wallets/transaction-status?transactionId=${encodeURIComponent(approveTx.transactionId)}`, { method: 'GET' });
-                if (approveStatus?.transactionState === 'COMPLETE') {
-                  break;
-                }
-                if (approveStatus?.transactionState === 'FAILED') {
-                  throw new Error(approveStatus?.error || approveStatus?.transaction?.errorDetails || 'Approve transaction failed');
-                }
-              } catch (pollError) {
-                console.warn('Error polling approve status:', pollError);
-              }
-            }
-          }
-        }
-      }
-
-      // Step 4: Create gift card on blockchain
       setStep('creating');
       toast.info('Creating gift card on blockchain...');
-      
-      let result;
-      
-      // Use different methods based on wallet type and recipient type
-      if (useDeveloperWallet) {
-        // Create card via Internal Wallet
-        const normalizedUsername = formData.recipientType !== 'address' 
-          ? formData.recipientUsername.toLowerCase().replace(/^@/, '').trim()
-          : '';
-        
-        let functionName: string;
-        let args: any[];
-        
-        if (formData.recipientType === 'twitter') {
-          functionName = 'createGiftCardForTwitter';
-          args = [normalizedUsername, BigInt(amountWei), tokenAddress, metadataUri, formData.message];
-        } else if (formData.recipientType === 'twitch') {
-          functionName = 'createGiftCardForTwitch';
-          args = [normalizedUsername, BigInt(amountWei), tokenAddress, metadataUri, formData.message];
-        } else if (formData.recipientType === 'telegram') {
-          functionName = 'createGiftCardForTelegram';
-          args = [normalizedUsername, BigInt(amountWei), tokenAddress, metadataUri, formData.message];
-        } else if (formData.recipientType === 'tiktok') {
-          functionName = 'createGiftCardForTikTok';
-          args = [normalizedUsername, BigInt(amountWei), tokenAddress, metadataUri, formData.message];
-        } else if (formData.recipientType === 'instagram') {
-          functionName = 'createGiftCardForInstagram';
-          args = [normalizedUsername, BigInt(amountWei), tokenAddress, metadataUri, formData.message];
-        } else {
-          // Address recipient
-          functionName = 'createGiftCard';
-          args = [formData.recipientAddress, BigInt(amountWei), tokenAddress, metadataUri, formData.message];
-        }
-        
-        // Get social platform info for transaction
-        let socialPlatform: string | undefined;
-        let socialUserId: string | undefined;
-        if (developerWallet) {
-          socialPlatform = developerWallet.social_platform || undefined;
-          socialUserId = developerWallet.social_user_id || undefined;
-        }
-        
-        // Determine privyUserId - if wallet was created with user_id = MetaMask address (and no privy_user_id),
-        // use MetaMask address instead of Privy ID for verification
-        let privyUserIdForTx: string | undefined = undefined;
-        
-        // Check if wallet was created with user_id = address (no privy_user_id in DB)
-        const walletCreatedWithAddress = developerWallet && 
-          developerWallet.user_id && 
-          developerWallet.user_id.startsWith('0x') && 
-          !developerWallet.privy_user_id &&
-          isConnected && 
-          address &&
-          developerWallet.user_id.toLowerCase() === address.toLowerCase();
-        
-        if (walletCreatedWithAddress) {
-          // Wallet was created with user_id = MetaMask address, use address for verification
-          privyUserIdForTx = address.toLowerCase();
-        } else if (privyUser?.id) {
-          // Use Privy ID as normal
-          privyUserIdForTx = privyUser.id.startsWith('did:privy:') 
-            ? privyUser.id.replace('did:privy:', '') 
-            : privyUser.id;
-        } else if (isConnected && address) {
-          // If no Privy auth but MetaMask is connected, use MetaMask address
-          privyUserIdForTx = address.toLowerCase();
-        }
-        // Note: If user is authenticated only via social account (no MetaMask),
-        // privyUserId may be undefined, but socialPlatform/socialUserId will be used for verification
-        
-        // Send transaction via Internal Wallet
-        const txResult = await DeveloperWalletService.sendTransaction({
-          walletId: developerWallet.circle_wallet_id,
-          walletAddress: developerWallet.wallet_address,
-          contractAddress: contracts.contractAddress!,
-          functionName: functionName,
-          args: args,
-          blockchain: 'ARC-TESTNET',
-          privyUserId: privyUserIdForTx,
-          socialPlatform: socialPlatform,
-          socialUserId: socialUserId
-        });
-        
-        if (!txResult.success) {
-          // Provide more specific error message
-          const errorMessage = txResult.error || 'Failed to create gift card';
-          // Error details logged on backend only
-          
-          // Check for common error patterns
-          if (errorMessage.includes('balance') || errorMessage.includes('insufficient')) {
-            throw new Error(`Insufficient ${formData.currency} balance. Please ensure you have enough tokens to create this gift card.`);
-          } else if (errorMessage.includes('allowance') || errorMessage.includes('approve')) {
-            throw new Error('Token approval failed. Please try again.');
-          } else if (errorMessage.includes('Vault not set') || errorMessage.includes('vault')) {
-            throw new Error('Vault contract not configured. Please contact support.');
-          } else if (errorMessage.includes('Username required') || errorMessage.includes('username')) {
-            throw new Error('Invalid username. Please check the username and try again.');
-          }
-          
-          throw new Error(errorMessage);
-        }
-        
-        // If txHash is not yet available, poll the transaction status until txHash is received
-        let finalTxHash = txResult.txHash;
-        if (!finalTxHash && txResult.transactionId) {
-          toast.info('Waiting for transaction to be processed...');
-          
-          // Poll transaction status via Circle API
-          const maxAttempts = 30; // Maximum 30 attempts (~30 seconds)
-          const pollInterval = 1000; // 1 second between attempts
-          
-          for (let attempt = 0; attempt < maxAttempts; attempt++) {
-            await new Promise(resolve => setTimeout(resolve, pollInterval));
-            
-              try {
-                // Use common apiCall helper to set Authorization
-              const statusData = await apiCall(`/wallets/transaction-status?transactionId=${encodeURIComponent(txResult.transactionId)}`, {
-                method: 'GET'
-              });
-              
-              if (statusData) {
-                if (statusData.txHash) {
-                  finalTxHash = statusData.txHash;
-                  break;
-                }
-                // If the transaction failed
-                if (statusData.transactionState === 'FAILED') {
-                  // Get more detailed error information
-                  const errorDetails = statusData.transaction?.errorDetails || 
-                                     statusData.transaction?.error || 
-                                     statusData.error || 
-                                     'Transaction failed';
-                  const errorMessage = typeof errorDetails === 'string' 
-                    ? errorDetails 
-                    : JSON.stringify(errorDetails);
-                  
-                  // Transaction failure details logged on backend only
-                  
-                  // Provide more specific error message
-                  let userFriendlyError = 'Transaction failed';
-                  if (errorMessage.includes('transfer amount exceeds balance') || 
-                      errorMessage.includes('insufficient balance') ||
-                      errorMessage.includes('ERC20')) {
-                    userFriendlyError = `Insufficient ${formData.currency} balance. Please ensure you have enough tokens to create this gift card.`;
-                  } else if (errorMessage.includes('allowance')) {
-                    userFriendlyError = 'Token approval failed. Please try again.';
-                  } else if (errorMessage.includes('Vault not set') || errorMessage.includes('vault')) {
-                    userFriendlyError = 'Vault contract not configured. Please contact support.';
-                  } else if (errorMessage.includes('Username required') || errorMessage.includes('username')) {
-                    userFriendlyError = 'Invalid username. Please check the username and try again.';
-                  }
-                  
-                  throw new Error(userFriendlyError);
-                }
-                // If transaction is completed but no txHash yet, continue polling
-                if (statusData.transactionState === 'COMPLETE' && !statusData.txHash) {
-                  // Wait a bit more for txHash to appear
-                  await new Promise(resolve => setTimeout(resolve, 2000));
-                  // Try one more time
-                  const retryStatusData = await apiCall(`/wallets/transaction-status?transactionId=${encodeURIComponent(txResult.transactionId)}`, {
-                    method: 'GET'
-                  });
-                  if (retryStatusData?.txHash) {
-                    finalTxHash = retryStatusData.txHash;
-                    break;
-                  }
-                }
-              }
-            } catch (pollError) {
-              // If it's a transaction failure error, re-throw it
-              if (pollError instanceof Error && pollError.message !== 'Transaction failed') {
-                throw pollError;
-              }
-              console.warn('Error polling transaction status:', pollError);
-              // Continue polling only if it's not a transaction failure
-              if (pollError instanceof Error && pollError.message.includes('Transaction failed')) {
-                throw pollError;
-              }
-            }
-          }
-          
-          if (!finalTxHash) {
-            // If there is still no txHash, use transactionId for display
-            // and show a message to the user
-            toast.warning('Transaction is being processed. Please check status later.');
-            // Use transactionId as a temporary identifier
-            finalTxHash = txResult.transactionId || 'pending';
-          }
-        }
-        
-        if (!finalTxHash) {
-          throw new Error('Failed to get transaction hash');
-        }
-        
-        // If txHash is not ready yet (pending), do not wait for receipt
-        if (finalTxHash === 'pending' || finalTxHash === txResult.transactionId) {
-          // Use transactionId to store the card
-          result = {
-            tokenId: 'pending', // Will be updated later
-            txHash: txResult.transactionId || 'pending'
-          };
-        } else {
-          // Wait for transaction receipt and extract tokenId
-          const publicClient = createPublicClient({
-            chain: activeChain,
-            transport: http()
+
+      const result = useDeveloperWallet
+        ? await createGiftCardWithDeveloperWallet({
+            activeChain,
+            contracts,
+            formData,
+            metadataUri,
+            amountWei,
+            tokenAddress,
+            createAddress,
+            developerWallet,
+            isConnected,
+            address,
+            privyUserId: privyUser?.id,
+            notifyInfo: toast.info,
+            notifyWarning: toast.warning
+          })
+        : await createGiftCardWithConnectedWallet({
+            walletClient,
+            activeChain,
+            activeChainId,
+            createAddress,
+            formData,
+            metadataUri
           });
-          
-          const receipt = await publicClient.waitForTransactionReceipt({
-            hash: finalTxHash as `0x${string}`
-          });
-          
-          // Check transaction status - if it failed, throw an error
-          if (receipt.status === 'reverted' || (typeof receipt.status === 'number' && receipt.status === 0)) {
-            throw new Error(`Transaction failed: ERC20 transfer amount exceeds balance or other contract error. Transaction hash: ${finalTxHash}`);
-          }
-          
-          // Extract tokenId from Transfer event
-          const transferEventSignature = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
-          const zeroAddress = '0x0000000000000000000000000000000000000000';
-          const zeroAddressTopic = '0x' + zeroAddress.slice(2).padStart(64, '0');
-          
-          let tokenId = '1'; // Default fallback
-          const transferEvent = receipt.logs.find((log: any) => 
-            log.topics[0] === transferEventSignature &&
-            log.topics[1]?.toLowerCase() === zeroAddressTopic.toLowerCase() &&
-            (log.address.toLowerCase() === contracts.contractAddress!.toLowerCase() ||
-             log.address.toLowerCase() === (formData.recipientType === 'twitter' ? contracts.vaultContract! :
-                                          formData.recipientType === 'twitch' ? contracts.twitchVault! :
-                                          formData.recipientType === 'telegram' ? contracts.telegramVault! :
-                                          formData.recipientType === 'tiktok' ? contracts.tiktokVault! :
-                                          formData.recipientType === 'instagram' ? contracts.instagramVault! :
-                                          contracts.contractAddress!).toLowerCase())
-          );
-          
-          if (transferEvent && transferEvent.topics[3]) {
-            tokenId = BigInt(transferEvent.topics[3]).toString();
-          }
-          
-          result = {
-            tokenId: tokenId,
-            txHash: finalTxHash
-          };
-        }
-      } else {
-        // Create card via MetaMask (existing logic)
-        // Initialize web3 service
-        let clientToUse = walletClient;
-        if (!clientToUse) {
-          // Creating manual wallet client
-          clientToUse = createWalletClient({
-            chain: activeChain,
-            transport: custom(window.ethereum)
-          });
-        }
-
-        await web3Service.initialize(clientToUse, createAddress, activeChainId);
-        
-        // Use different methods based on recipient type
-        if (formData.recipientType === 'twitter') {
-          // Normalize username for consistency (createCardForTwitter also normalizes)
-          const normalizedUsername = formData.recipientUsername.toLowerCase().replace(/^@/, '').trim();
-          // Creating Twitter card
-          
-          // Use new Vault flow for Twitter cards
-          result = await web3Service.createCardForTwitter(
-            normalizedUsername, // Using normalized username
-            formData.amount,
-            formData.currency,
-            metadataUri,
-            formData.message
-          );
-          
-          // Still save metadata to KV for additional info (using normalized username)
-          try {
-            await createTwitterCardMapping({
-              tokenId: result.tokenId,
-              username: normalizedUsername, // Saving normalized username
-              temporaryOwner: '', // No longer needed with Vault
-              senderAddress: createAddress,
-              amount: formData.amount,
-              currency: formData.currency,
-              message: formData.message,
-              metadataUri: metadataUri
-            });
-          } catch (error) {
-            console.error('Error saving Twitter card metadata:', error);
-            // Non-critical error, card is already created on blockchain
-          }
-        } else if (formData.recipientType === 'twitch') {
-          const normalizedUsername = formData.recipientUsername.toLowerCase().trim();
-          // Creating Twitch card
-          
-          result = await web3Service.createCardForTwitch(
-            normalizedUsername,
-            formData.amount,
-            formData.currency,
-            metadataUri,
-            formData.message
-          );
-          
-          try {
-            await createTwitchCardMapping({
-              tokenId: result.tokenId,
-              username: normalizedUsername,
-              temporaryOwner: '',
-              senderAddress: createAddress,
-              amount: formData.amount,
-              currency: formData.currency,
-              message: formData.message,
-              metadataUri: metadataUri
-            });
-          } catch (error) {
-            console.error('Error saving Twitch card metadata:', error);
-          }
-        } else if (formData.recipientType === 'telegram') {
-          const normalizedUsername = formData.recipientUsername.toLowerCase().replace(/^@/, '').trim();
-          // Creating Telegram card
-
-          result = await web3Service.createCardForTelegram(
-            normalizedUsername,
-            formData.amount,
-            formData.currency,
-            metadataUri,
-            formData.message
-          );
-
-          try {
-            await createTelegramCardMapping({
-              tokenId: result.tokenId,
-              username: normalizedUsername,
-              temporaryOwner: '',
-              senderAddress: createAddress,
-              amount: formData.amount,
-              currency: formData.currency,
-              message: formData.message,
-              metadataUri: metadataUri
-            });
-          } catch (error) {
-            console.error('Error saving Telegram card metadata:', error);
-          }
-        } else if (formData.recipientType === 'tiktok') {
-          const normalizedUsername = formData.recipientUsername.toLowerCase().replace(/^@/, '').trim();
-          // Creating TikTok card
-
-          result = await web3Service.createCardForTikTok(
-            normalizedUsername,
-            formData.amount,
-            formData.currency,
-            metadataUri,
-            formData.message
-          );
-
-          try {
-            await createTikTokCardMapping({
-              tokenId: result.tokenId,
-              username: normalizedUsername,
-              temporaryOwner: '',
-              senderAddress: createAddress,
-              amount: formData.amount,
-              currency: formData.currency,
-              message: formData.message,
-              metadataUri: metadataUri
-            });
-          } catch (error) {
-            console.error('Error saving TikTok card metadata:', error);
-          }
-        } else if (formData.recipientType === 'instagram') {
-          const normalizedUsername = formData.recipientUsername.toLowerCase().replace(/^@/, '').trim();
-          // Creating Instagram card
-
-          result = await web3Service.createCardForInstagram(
-            normalizedUsername,
-            formData.amount,
-            formData.currency,
-            metadataUri,
-            formData.message
-          );
-
-          try {
-            await createInstagramCardMapping({
-              tokenId: result.tokenId,
-              username: normalizedUsername,
-              temporaryOwner: '',
-              senderAddress: createAddress,
-              amount: formData.amount,
-              currency: formData.currency,
-              message: formData.message,
-              metadataUri: metadataUri
-            });
-          } catch (error) {
-            console.error('Error saving Instagram card metadata:', error);
-          }
-        } else {
-          // Standard flow for address recipients
-          result = await web3Service.createGiftCard(
-            formData.recipientAddress,
-            formData.amount,
-            formData.currency,
-            metadataUri,
-            formData.message
-          );
-        }
-      }
 
       setStep('success');
-      setErrorTxHash(null); // Clear any previous error hash on success
-      
-      const createdCardData = {
-        id: result.tokenId,
-        recipientAddress: formData.recipientAddress,
-        amount: formData.amount,
-        currency: formData.currency,
-        design: formData.design,
-        message: formData.message,
-        secretMessage: formData.secretMessage,
-        hasTimer: formData.hasTimer,
-        timerHours: formData.timerHours,
-        hasPassword: formData.hasPassword,
-        expiryDays: formData.expiryDays,
-        customImage: formData.customImage,
-        nftCover: formData.nftCover,
-        status: 'active',
-        created_at: new Date().toISOString(),
-        expires_at: new Date(Date.now() + formData.expiryDays * 24 * 60 * 60 * 1000).toISOString(),
-        qr_code: `/spend?tokenId=${result.tokenId}`,
-        tx_hash: result.txHash,
-        metadata_uri: metadataUri
-      };
-
-      setCreatedCard(createdCardData);
+      setErrorTxHash(null);
+      setCreatedCard(buildCreatedCardData({ result, formData, metadataUri }));
       toast.success('Gift card created successfully!');
       toast.success(`Gift card created successfully! TX: ${result.txHash.slice(0, 10)}...${result.txHash.slice(-8)}`);
-      
-      // Save to Supabase for caching
+
       try {
-        const recipientUsernameForStorage =
-          formData.recipientType === 'address'
-            ? null
-            : formData.recipientUsername.replace(/^@/, '').trim();
-        
-        // Determine event_type based on recipient type
-        let eventType: string | null = null;
-        if (formData.recipientType === 'twitter') {
-          eventType = 'GiftCardCreatedForTwitter';
-        } else if (formData.recipientType === 'twitch') {
-          eventType = 'GiftCardCreatedForTwitch';
-        } else if (formData.recipientType === 'telegram') {
-          eventType = 'GiftCardCreatedForTelegram';
-        } else if (formData.recipientType === 'tiktok') {
-          eventType = 'GiftCardCreatedForTikTok';
-        } else if (formData.recipientType === 'instagram') {
-          eventType = 'GiftCardCreatedForInstagram';
-        } else {
-          eventType = 'GiftCardCreated';
-        }
-
-        // Save to gift_cards table
-        await GiftCardsService.upsertCard({
-          token_id: result.tokenId,
-          chain_id: activeChainId,
-          sender_address: (createAddress || '').toLowerCase(),
-          recipient_address: formData.recipientType === 'address' ? formData.recipientAddress.toLowerCase() : null,
-          recipient_username: recipientUsernameForStorage,
-          recipient_type: formData.recipientType,
-          amount: formData.amount,
-          currency: formData.currency,
-          message: formData.message,
-          redeemed: false,
-          tx_hash: result.txHash,
-        }, activeChainId);
-
-        // Save new IPFS URI to uri table (commented out -  only saving in gift_cards_graph)
-        // await insertFakeUri(metadataUri, result.tokenId);
-
-        // Also save to gift_cards_graph table for leaderboard calculations
-        await GiftCardsService.upsertCardGraph({
-          token_id: result.tokenId,
-          chain_id: activeChainId,
-          sender_address: (createAddress || '').toLowerCase(),
-          recipient_address: formData.recipientType === 'address' ? formData.recipientAddress.toLowerCase() : null,
-          recipient_username: recipientUsernameForStorage,
-          recipient_type: formData.recipientType,
-          amount: formData.amount,
-          currency: formData.currency,
-          message: formData.message,
-          redeemed: false,
-          tx_hash: result.txHash,
-          event_type: eventType,
-          uri: metadataUri,
-          block_number: null,
-          block_timestamp: null,
-        }, activeChainId);
-        
-        // Card saved to Supabase cache and graph table
+        await saveCreatedGiftCard({
+          result,
+          formData,
+          activeChainId,
+          createAddress,
+          metadataUri
+        });
       } catch (error) {
         console.error('Error saving card to Supabase:', error);
       }
-      
-      // Reset form
-      setFormData({
-        recipientType: 'address',
-        recipientAddress: '',
-        recipientUsername: '',
-        amount: '1',
-        currency: 'USDC',
-        design: 'pink',
-        message: '',
-        secretMessage: '',
-        hasTimer: false,
-        timerHours: 24,
-        hasPassword: false,
-        password: '',
-        expiryDays: 7,
-        customImage: '',
-        nftCover: ''
-      });
+
+      setFormData(RESET_GIFT_CARD_DATA);
     } catch (error) {
       console.error('Error creating gift card:', error);
-      
+
       const errorMessage = error instanceof Error ? error.message : 'Failed to create gift card';
-      const errorCode = (error as any)?.code;
-      const txHashMatch = errorMessage.match(/0x[a-fA-F0-9]{64}/);
-      const txHash = txHashMatch ? txHashMatch[0] : null;
+      const txHash = extractTxHashFromError(errorMessage);
       setErrorTxHash(txHash);
 
-      // User rejected transaction -  short popup message
-      const isUserRejected =
-        errorCode === 4001 ||
-        errorMessage.toLowerCase().includes('user rejected') ||
-        errorMessage.toLowerCase().includes('rejected the request') ||
-        errorMessage.toLowerCase().includes('user denied') ||
-        errorMessage.toLowerCase().includes('denied transaction');
-      if (isUserRejected) {
+      const errorPresentation = classifyCreateGiftCardError({
+        error,
+        errorMessage,
+        currency: formData.currency,
+        txHash,
+        isCoinbaseWallet: typeof window !== 'undefined' && (window as any).ethereum?.isCoinbaseWallet
+      });
+
+      if (errorPresentation.type === 'canceled') {
         setError('');
         setErrorTxHash(null);
         toast('Canceled', { duration: 2000 });
         return;
       }
-      
-      // Check if it's a chain ID error with Coinbase Wallet
-      if (errorMessage.includes('invalid chain ID') && typeof window !== 'undefined' && (window as any).ethereum?.isCoinbaseWallet) {
-        setError('Coinbase Wallet has issues with Arc Testnet. Please use MetaMask or Rainbow Wallet to work with Arc Testnet.');
+
+      setError(errorPresentation.message);
+      if (errorPresentation.clearTxHash) {
         setErrorTxHash(null);
-        toast.error('Error: use MetaMask or Rainbow Wallet', {
-          description: 'Coinbase Wallet is not supported for Arc Testnet'
-        });
-      } else if (errorMessage.includes('ERC20') || errorMessage.includes('transfer amount exceeds balance') || errorMessage.includes('Insufficient') || errorMessage.includes('balance')) {
-        // More specific error for balance/transfer issues
-        const baseMessage = errorMessage.includes('Insufficient') 
-          ? errorMessage
-          : `Insufficient ${formData.currency} balance. Please ensure you have enough tokens to create this gift card.`;
-        setError(baseMessage);
-        
-        // Show toast with transaction hash if available
-        const toastDescription = txHash 
-          ? `${baseMessage}\nTX: ${txHash.slice(0, 10)}...${txHash.slice(-8)}`
-          : baseMessage;
-        toast.error('Transaction failed', {
-          description: toastDescription
-        });
-      } else if (errorMessage.includes('Transaction failed')) {
-        // Handle generic transaction failed errors
-        setError(errorMessage);
-        toast.error('Transaction failed', {
-          description: errorMessage
-        });
-      } else if (errorMessage.includes('Vault not configured') || errorMessage.includes('Vault contract')) {
-        // Handle vault configuration errors
-        setError(errorMessage);
-        toast.error('Configuration error', {
-          description: errorMessage
-        });
-      } else if (errorMessage.includes('Invalid username') || errorMessage.includes('username')) {
-        // Handle username validation errors
-        setError(errorMessage);
-        toast.error('Invalid username', {
-          description: errorMessage
-        });
-      } else {
-        setError(errorMessage);
-        toast.error('Failed to create gift card', {
-          description: errorMessage
-        });
       }
+      toast.error(errorPresentation.toastTitle, {
+        description: errorPresentation.toastDescription
+      });
     } finally {
       setIsCreating(false);
       setStep('form');
     }
   };
-
   const handleShare = (method?: 'email' | 'x' | 'tiktok' | 'copy') => {
     if (!createdCard) return;
     
@@ -1453,7 +419,7 @@ export function CreateGiftCard() {
                     />
                     <div className="flex items-center space-x-2.5 flex-1">
                       <div className={`flex-shrink-0 ${
-                        option.icon === 'wallet' ? 'text-blue-600' :
+                        option.icon === 'address' ? 'text-blue-600' :
                         option.icon === 'twitter' ? 'text-gray-900' :
                         option.icon === 'twitch' ? 'text-purple-600' :
                         option.icon === 'telegram' ? 'text-sky-500' :
@@ -1461,7 +427,7 @@ export function CreateGiftCard() {
                         option.icon === 'instagram' ? 'text-pink-600' :
                         'text-gray-700'
                       }`}>
-                        {renderPlatformIcon(option.icon, "w-5 h-5")}
+                        <PlatformIcon platform={option.icon} className="w-5 h-5" />
                       </div>
                       <Label 
                         htmlFor={option.value} 

--- a/src/components/DeveloperWallet.tsx
+++ b/src/components/DeveloperWallet.tsx
@@ -1099,4 +1099,3 @@ export function DeveloperWalletComponent({ blockchain = 'ARC-TESTNET', onWalletC
     </Card>
   );
 }
-

--- a/src/components/TransactionHistory.tsx
+++ b/src/components/TransactionHistory.tsx
@@ -14,7 +14,8 @@ import { createWalletClient, custom } from 'viem';
 import { arcTestnet, chains } from '@/lib/web3/wagmiConfig';
 import { getExplorerTxUrl, getContractsForChain, ARC_CHAIN_ID } from '@/lib/web3/constants';
 import web3Service from '@/lib/web3/web3Service';
-import { GiftCardsService } from '@/lib/supabase/giftCards';
+import { GiftCardsService, getMyCardsDataSource } from '@/lib/supabase/giftCards';
+import { formatDisplayAmount, formatTokenAmountString } from '@/lib/tokenAmount';
 import { isZkHost } from '@/lib/runtime/zkHost';
 import {
   getZkSendPaymentsBySender,
@@ -63,6 +64,15 @@ function normalizePlatform(p?: string | null): SocialPlatform {
   return '';
 }
 
+function AnalyticsAmount({ value, className }: { value: string; className?: string }) {
+  const rounded = formatDisplayAmount(value);
+  return (
+    <div className={`tabular-nums ${className ?? ''}`}>
+      ${rounded}
+    </div>
+  );
+}
+
 function toTransactionFromSent(row: ZkSendPaymentRow): Transaction {
   const counterpart =
     row.recipient_username ?? row.recipient_username_raw ?? row.recipient_identity_hash ?? '-';
@@ -74,7 +84,7 @@ function toTransactionFromSent(row: ZkSendPaymentRow): Transaction {
   return {
     id: `zksend_sent_${row.chain_id}_${row.contract_address}_${row.payment_id}`,
     type: 'sent',
-    amount: row.amount ?? '0',
+    amount: formatTokenAmountString(row.amount ?? '0', { unit: 'human' }),
     currency,
     counterpart,
     message: '',
@@ -111,7 +121,7 @@ function toTransactionFromReceived(row: ZkSendPaymentRow): Transaction {
   return {
     id: `zksend_recv_${row.chain_id}_${row.contract_address}_${row.payment_id}`,
     type: row.claimed ? 'redeemed' : 'received',
-    amount: row.amount ?? '0',
+    amount: formatTokenAmountString(row.amount ?? '0', { unit: 'human' }),
     currency,
     counterpart,
     message: '',
@@ -391,6 +401,7 @@ export function TransactionHistory() {
         const supa = supabaseReceivedMap.get(card.tokenId);
         return {
           ...card,
+          amount: formatTokenAmountString(card.amount, { unit: 'human' }),
           type: 'received' as const,
           txHash: supa?.tx_hash || (card as any).txHash || null,
           createdAt: supa?.created_at || null
@@ -401,10 +412,12 @@ export function TransactionHistory() {
       console.log('Loading sent gift cards from Supabase...');
       const supabaseSentCards = await GiftCardsService.getCardsBySenderForMyCards(address, activeChainId);
       
+      const sentAmountUnit = getMyCardsDataSource() === 'graph' ? 'micro' : 'human';
+
       // Transform Supabase sent cards to match blockchain format
       const sentCards = supabaseSentCards.map(card => ({
         tokenId: card.token_id,
-        amount: card.amount,
+        amount: formatTokenAmountString(card.amount, { unit: sentAmountUnit }),
         token: card.currency,
         recipient: card.recipient_username || card.recipient_address || 'Unknown',
         sender: card.sender_address,
@@ -814,7 +827,7 @@ export function TransactionHistory() {
               <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Total Sent</span>
               <ArrowUpRight className="h-3.5 w-3.5 text-red-500" />
             </div>
-            <div className="text-lg font-bold text-red-600 dark:text-red-400">${analytics.totalSent}</div>
+            <AnalyticsAmount value={analytics.totalSent} className="text-lg font-bold text-red-600 dark:text-red-400" />
             <p className="text-xs text-slate-500 dark:text-slate-400">{analytics.cardsSent} payments</p>
           </div>
           <div className="bg-slate-50 dark:bg-slate-800/50 rounded-lg p-3 border border-slate-200 dark:border-slate-700">
@@ -822,7 +835,7 @@ export function TransactionHistory() {
               <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Total Received</span>
               <ArrowDownLeft className="h-3.5 w-3.5 text-blue-500" />
             </div>
-            <div className="text-lg font-bold text-blue-600 dark:text-blue-400">${analytics.totalReceived}</div>
+            <AnalyticsAmount value={analytics.totalReceived} className="text-lg font-bold text-blue-600 dark:text-blue-400" />
             <p className="text-xs text-slate-500 dark:text-slate-400">{analytics.cardsReceived} payments</p>
           </div>
           <div className="bg-slate-50 dark:bg-slate-800/50 rounded-lg p-3 border border-slate-200 dark:border-slate-700">
@@ -853,12 +866,18 @@ export function TransactionHistory() {
                 </button>
               </div>
             </div>
-            <div className={`text-lg font-bold relative -top-[14px] ${avgMode === 'sent' ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'}`}>
-              $
-              {avgMode === 'sent'
-                ? (analytics.cardsSent > 0 ? (parseFloat(analytics.totalSent) / analytics.cardsSent).toFixed(2) : '0.00')
-                : (analytics.cardsReceived > 0 ? (parseFloat(analytics.totalReceived) / analytics.cardsReceived).toFixed(2) : '0.00')}
-            </div>
+            <AnalyticsAmount
+              value={
+                avgMode === 'sent'
+                  ? (analytics.cardsSent > 0
+                      ? formatDisplayAmount(parseFloat(analytics.totalSent) / analytics.cardsSent)
+                      : '0.00')
+                  : (analytics.cardsReceived > 0
+                      ? formatDisplayAmount(parseFloat(analytics.totalReceived) / analytics.cardsReceived)
+                      : '0.00')
+              }
+              className={`text-lg font-bold relative -top-[14px] ${avgMode === 'sent' ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'}`}
+            />
             <p className="text-xs text-slate-500 dark:text-slate-400 relative -top-[14px]">
               {avgMode === 'sent' ? 'per sent payment' : 'per received payment'}
             </p>
@@ -996,7 +1015,7 @@ export function TransactionHistory() {
               <ArrowUpRight className="h-4 w-4 text-red-500" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold text-red-600">${analytics.totalSent}</div>
+              <AnalyticsAmount value={analytics.totalSent} className="text-2xl font-bold text-red-600" />
               <p className="text-xs text-muted-foreground">{analytics.cardsSent} payments sent</p>
             </CardContent>
           </Card>
@@ -1006,7 +1025,7 @@ export function TransactionHistory() {
               <ArrowDownLeft className="h-4 w-4 text-green-500" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold text-green-600">${analytics.totalReceived}</div>
+              <AnalyticsAmount value={analytics.totalReceived} className="text-2xl font-bold text-green-600" />
               <p className="text-xs text-muted-foreground">{analytics.cardsReceived} payments received</p>
             </CardContent>
           </Card>
@@ -1016,7 +1035,7 @@ export function TransactionHistory() {
               <Gift className="h-4 w-4 text-blue-500" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold text-blue-600">${analytics.totalRedeemed}</div>
+              <AnalyticsAmount value={analytics.totalRedeemed} className="text-2xl font-bold text-blue-600" />
               <p className="text-xs text-muted-foreground">claimed</p>
             </CardContent>
           </Card>
@@ -1026,7 +1045,7 @@ export function TransactionHistory() {
               <TrendingUp className="h-4 w-4 text-purple-500" />
             </CardHeader>
             <CardContent>
-              <div className="text-2xl font-bold text-purple-600">${analytics.averageAmount}</div>
+              <AnalyticsAmount value={analytics.averageAmount} className="text-2xl font-bold text-purple-600" />
               <p className="text-xs text-muted-foreground">Per payment</p>
             </CardContent>
           </Card>

--- a/src/components/TransactionHistory.tsx
+++ b/src/components/TransactionHistory.tsx
@@ -14,7 +14,7 @@ import { createWalletClient, custom } from 'viem';
 import { arcTestnet, chains } from '@/lib/web3/wagmiConfig';
 import { getExplorerTxUrl, getContractsForChain, ARC_CHAIN_ID } from '@/lib/web3/constants';
 import web3Service from '@/lib/web3/web3Service';
-import { GiftCardsService, getMyCardsDataSource } from '@/lib/supabase/giftCards';
+import { GiftCardsService } from '@/lib/supabase/giftCards';
 import { formatDisplayAmount, formatTokenAmountString } from '@/lib/tokenAmount';
 import { isZkHost } from '@/lib/runtime/zkHost';
 import {
@@ -412,12 +412,10 @@ export function TransactionHistory() {
       console.log('Loading sent gift cards from Supabase...');
       const supabaseSentCards = await GiftCardsService.getCardsBySenderForMyCards(address, activeChainId);
       
-      const sentAmountUnit = getMyCardsDataSource() === 'graph' ? 'micro' : 'human';
-
       // Transform Supabase sent cards to match blockchain format
       const sentCards = supabaseSentCards.map(card => ({
         tokenId: card.token_id,
-        amount: formatTokenAmountString(card.amount, { unit: sentAmountUnit }),
+        amount: formatTokenAmountString(card.amount, { unit: 'human' }),
         token: card.currency,
         recipient: card.recipient_username || card.recipient_address || 'Unknown',
         sender: card.sender_address,

--- a/src/components/VoicePaymentAgent.tsx
+++ b/src/components/VoicePaymentAgent.tsx
@@ -129,16 +129,11 @@ export function VoicePaymentAgent() {
       setTranscribedText(text);
       toast.success('Speech recognized');
 
-      console.log('Transcribed text:', text);
-      console.log('Contacts:', contacts);
-
       const contactsWithWallet = contacts
         .filter(c => c.wallet)
         .map(c => ({ name: c.name, wallet: c.wallet! }));
       
       const parsed = await aimlapiService.parsePaymentCommand(text, contactsWithWallet);
-      
-      console.log('Parsed command:', parsed);
 
       if (!parsed) {
         throw new Error('Failed to process command');
@@ -152,10 +147,6 @@ export function VoicePaymentAgent() {
 
       const recipientNameLower = parsed.recipientName!.toLowerCase().trim();
       const contact = contacts.find(c => c.name.toLowerCase().trim() === recipientNameLower);
-      
-      console.log('Looking for contact:', parsed.recipientName, 'lowercase:', recipientNameLower);
-      console.log('Available contacts:', contacts.map(c => c.name));
-      console.log('Found contact:', contact);
       
       if (!contact) {
         setError('Contact not found');
@@ -178,11 +169,12 @@ export function VoicePaymentAgent() {
   };
 
   const confirmAndCreate = async () => {
-    if (!parsedCommand || !isConnected || !address) {
+    if (!parsedCommand?.recipientName || !isConnected || !address) {
       return;
     }
 
-    const contact = contacts.find(c => c.name.toLowerCase() === parsedCommand.recipientName.toLowerCase());
+    const recipientName = parsedCommand.recipientName;
+    const contact = contacts.find(c => c.name.toLowerCase() === recipientName.toLowerCase());
     if (!contact) {
       setError('Contact not found');
       return;

--- a/src/components/gift-card/PlatformIcon.tsx
+++ b/src/components/gift-card/PlatformIcon.tsx
@@ -1,0 +1,47 @@
+import { Wallet } from 'lucide-react';
+import type { PlatformIconName } from './recipientOptions';
+
+interface PlatformIconProps {
+  platform: PlatformIconName;
+  className?: string;
+}
+
+export function PlatformIcon({ platform, className = 'w-4 h-4' }: PlatformIconProps) {
+  switch (platform) {
+    case 'address':
+      return <Wallet className={className} />;
+    case 'twitter':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+        </svg>
+      );
+    case 'twitch':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+          <path d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0L1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143l-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714Z"/>
+        </svg>
+      );
+    case 'telegram':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+          <path d="M9.50039 15.0005L9.30305 18.7916C9.63343 18.7916 9.77653 18.6502 9.94861 18.4803L11.4982 16.9898L15.251 19.7367C15.9373 20.1197 16.4205 19.9285 16.6027 19.0304L18.9395 7.42573L18.9402 7.42504C19.1555 6.32428 18.5201 5.86444 17.851 6.13415L4.90234 11.1053C3.84037 11.5206 3.85629 12.1181 4.7964 12.3878L8.10118 13.3485L15.8533 8.52547C16.2199 8.28796 16.5538 8.42039 16.2799 8.6579L9.50039 15.0005Z" />
+        </svg>
+      );
+    case 'tiktok':
+      return (
+        <svg className={className} viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+          <path d="M19.59 6.69a4.83 4.83 0 0 1-3.77-4.25V2h-3.45v13.67a2.89 2.89 0 0 1-5.2 1.74 2.89 2.89 0 0 1 2.31-4.64 2.93 2.93 0 0 1 .88.13V9.4a6.84 6.84 0 0 0-1-.05A6.33 6.33 0 0 0 5 20.1a6.34 6.34 0 0 0 10.86-4.43v-7a8.16 8.16 0 0 0 4.77 1.52v-3.4a4.85 4.85 0 0 1-1-.1z"/>
+        </svg>
+      );
+    case 'instagram':
+      return (
+        <svg className={className} viewBox="0 0 512 512" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+          <path d="M349.33 69.33a93.62 93.62 0 0193.34 93.34v186.66a93.62 93.62 0 01-93.34 93.34H162.67a93.62 93.62 0 01-93.34-93.34V162.67a93.62 93.62 0 0193.34-93.34h186.66m0-37.33H162.67C90.8 32 32 90.8 32 162.67v186.66C32 421.2 90.8 480 162.67 480h186.66C421.2 480 480 421.2 480 349.33V162.67C480 90.8 421.2 32 349.33 32z"/>
+          <path d="M377.33 162.67a28 28 0 1128-28 27.94 27.94 0 01-28 28zM256 181.33A74.67 74.67 0 11181.33 256 74.75 74.75 0 01256 181.33m0-37.33a112 112 0 10112 112 112 112 0 00-112-112z"/>
+        </svg>
+      );
+    default:
+      return null;
+  }
+}

--- a/src/components/gift-card/circleTransactionStatus.ts
+++ b/src/components/gift-card/circleTransactionStatus.ts
@@ -1,0 +1,95 @@
+import { apiCall } from '@/lib/supabase/client';
+import type { GiftCardCurrency } from './types';
+import { formatDeveloperWalletError } from './giftCardErrors';
+
+const MAX_STATUS_ATTEMPTS = 30;
+const POLL_INTERVAL_MS = 1000;
+
+export async function waitForCircleTransactionCompletion(transactionId: string) {
+  for (let attempt = 0; attempt < MAX_STATUS_ATTEMPTS; attempt++) {
+    await delay(POLL_INTERVAL_MS);
+    try {
+      const status = await getCircleTransactionStatus(transactionId);
+      if (status?.transactionState === 'COMPLETE') {
+        return;
+      }
+      if (status?.transactionState === 'FAILED') {
+        throw new Error(status?.error || status?.transaction?.errorDetails || 'Approve transaction failed');
+      }
+    } catch (pollError) {
+      console.warn('Error polling approve status:', pollError);
+    }
+  }
+}
+
+export async function resolveCircleTransactionHash(params: {
+  transactionId?: string;
+  txHash?: string;
+  currency: GiftCardCurrency;
+  notifyInfo: (message: string) => void;
+  notifyWarning: (message: string) => void;
+}) {
+  const { transactionId, txHash, currency, notifyInfo, notifyWarning } = params;
+  if (txHash || !transactionId) {
+    return txHash;
+  }
+
+  notifyInfo('Waiting for transaction to be processed...');
+
+  for (let attempt = 0; attempt < MAX_STATUS_ATTEMPTS; attempt++) {
+    await delay(POLL_INTERVAL_MS);
+
+    try {
+      const statusData = await getCircleTransactionStatus(transactionId);
+
+      if (statusData?.txHash) {
+        return statusData.txHash;
+      }
+
+      if (statusData?.transactionState === 'FAILED') {
+        throw new Error(getCircleTransactionFailureMessage(statusData, currency));
+      }
+
+      if (statusData?.transactionState === 'COMPLETE' && !statusData.txHash) {
+        await delay(2000);
+        const retryStatusData = await getCircleTransactionStatus(transactionId);
+        if (retryStatusData?.txHash) {
+          return retryStatusData.txHash;
+        }
+      }
+    } catch (pollError) {
+      if (pollError instanceof Error && pollError.message !== 'Transaction failed') {
+        throw pollError;
+      }
+      console.warn('Error polling transaction status:', pollError);
+      if (pollError instanceof Error && pollError.message.includes('Transaction failed')) {
+        throw pollError;
+      }
+    }
+  }
+
+  notifyWarning('Transaction is being processed. Please check status later.');
+  return transactionId || 'pending';
+}
+
+async function getCircleTransactionStatus(transactionId: string) {
+  return apiCall(`/wallets/transaction-status?transactionId=${encodeURIComponent(transactionId)}`, {
+    method: 'GET'
+  });
+}
+
+function getCircleTransactionFailureMessage(statusData: any, currency: GiftCardCurrency) {
+  const errorDetails = statusData.transaction?.errorDetails ||
+    statusData.transaction?.error ||
+    statusData.error ||
+    'Transaction failed';
+  const errorMessage = typeof errorDetails === 'string'
+    ? errorDetails
+    : JSON.stringify(errorDetails);
+
+  return formatDeveloperWalletError(errorMessage, currency, 'Transaction failed');
+}
+
+function delay(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/src/components/gift-card/connectedWalletFlow.ts
+++ b/src/components/gift-card/connectedWalletFlow.ts
@@ -1,0 +1,56 @@
+import { createWalletClient, custom } from 'viem';
+import web3Service from '@/lib/web3/web3Service';
+import type { GiftCardData } from './types';
+import type { GiftCardCreationResult } from './flowTypes';
+import { normalizeRecipientUsername } from './giftCardRequest';
+import { createSocialGiftCard, saveSocialCardMapping } from './socialGiftCardAdapters';
+
+export async function createGiftCardWithConnectedWallet(params: {
+  walletClient: any;
+  activeChain: any;
+  activeChainId: number;
+  createAddress: string;
+  formData: GiftCardData;
+  metadataUri: string;
+}): Promise<GiftCardCreationResult> {
+  const { activeChain, activeChainId, createAddress, formData, metadataUri } = params;
+  let clientToUse = params.walletClient;
+  if (!clientToUse) {
+    clientToUse = createWalletClient({
+      chain: activeChain,
+      transport: custom((window as any).ethereum)
+    });
+  }
+
+  await web3Service.initialize(clientToUse, createAddress, activeChainId);
+
+  if (formData.recipientType === 'address') {
+    return web3Service.createGiftCard(
+      formData.recipientAddress,
+      formData.amount,
+      formData.currency,
+      metadataUri,
+      formData.message
+    );
+  }
+
+  const normalizedUsername = normalizeConnectedWalletRecipientUsername(formData);
+  const result = await createSocialGiftCard({ formData, normalizedUsername, metadataUri });
+  await saveSocialCardMapping({
+    formData,
+    result,
+    normalizedUsername,
+    createAddress,
+    metadataUri
+  });
+
+  return result;
+}
+
+function normalizeConnectedWalletRecipientUsername(formData: GiftCardData) {
+  if (formData.recipientType === 'twitch') {
+    return formData.recipientUsername.toLowerCase().trim();
+  }
+
+  return normalizeRecipientUsername(formData);
+}

--- a/src/components/gift-card/createdGiftCardData.ts
+++ b/src/components/gift-card/createdGiftCardData.ts
@@ -1,0 +1,32 @@
+import type { GiftCardData } from './types';
+import type { GiftCardCreationResult } from './flowTypes';
+
+export function buildCreatedCardData(params: {
+  result: GiftCardCreationResult;
+  formData: GiftCardData;
+  metadataUri: string;
+}) {
+  const { result, formData, metadataUri } = params;
+
+  return {
+    id: result.tokenId,
+    recipientAddress: formData.recipientAddress,
+    amount: formData.amount,
+    currency: formData.currency,
+    design: formData.design,
+    message: formData.message,
+    secretMessage: formData.secretMessage,
+    hasTimer: formData.hasTimer,
+    timerHours: formData.timerHours,
+    hasPassword: formData.hasPassword,
+    expiryDays: formData.expiryDays,
+    customImage: formData.customImage,
+    nftCover: formData.nftCover,
+    status: 'active',
+    created_at: new Date().toISOString(),
+    expires_at: new Date(Date.now() + formData.expiryDays * 24 * 60 * 60 * 1000).toISOString(),
+    qr_code: `/spend?tokenId=${result.tokenId}`,
+    tx_hash: result.txHash,
+    metadata_uri: metadataUri
+  };
+}

--- a/src/components/gift-card/developerWalletCall.ts
+++ b/src/components/gift-card/developerWalletCall.ts
@@ -1,0 +1,46 @@
+import type { GiftCardData } from './types';
+import { normalizeRecipientUsername } from './giftCardRequest';
+
+export function getDeveloperWalletCall(params: {
+  formData: GiftCardData;
+  amountWei: string;
+  tokenAddress: string;
+  metadataUri: string;
+}) {
+  const { formData, amountWei, tokenAddress, metadataUri } = params;
+  const normalizedUsername = normalizeRecipientUsername(formData);
+  const amount = BigInt(amountWei);
+
+  switch (formData.recipientType) {
+    case 'twitter':
+      return {
+        functionName: 'createGiftCardForTwitter',
+        args: [normalizedUsername, amount, tokenAddress, metadataUri, formData.message]
+      };
+    case 'twitch':
+      return {
+        functionName: 'createGiftCardForTwitch',
+        args: [normalizedUsername, amount, tokenAddress, metadataUri, formData.message]
+      };
+    case 'telegram':
+      return {
+        functionName: 'createGiftCardForTelegram',
+        args: [normalizedUsername, amount, tokenAddress, metadataUri, formData.message]
+      };
+    case 'tiktok':
+      return {
+        functionName: 'createGiftCardForTikTok',
+        args: [normalizedUsername, amount, tokenAddress, metadataUri, formData.message]
+      };
+    case 'instagram':
+      return {
+        functionName: 'createGiftCardForInstagram',
+        args: [normalizedUsername, amount, tokenAddress, metadataUri, formData.message]
+      };
+    case 'address':
+      return {
+        functionName: 'createGiftCard',
+        args: [formData.recipientAddress, amount, tokenAddress, metadataUri, formData.message]
+      };
+  }
+}

--- a/src/components/gift-card/developerWalletFlow.ts
+++ b/src/components/gift-card/developerWalletFlow.ts
@@ -1,0 +1,122 @@
+import { createPublicClient, http } from 'viem';
+import { DeveloperWalletService } from '@/lib/circle/developerWalletService';
+import type { GiftCardData } from './types';
+import type { GiftCardCreationResult } from './flowTypes';
+import { formatDeveloperWalletError } from './giftCardErrors';
+import { resolveCircleTransactionHash } from './circleTransactionStatus';
+import { approveDeveloperWalletIfNeeded, assertDeveloperWalletBalance } from './developerWalletTokenOps';
+import { extractTokenIdFromReceipt } from './giftCardReceipt';
+import { getDeveloperWalletCall } from './developerWalletCall';
+import { getPrivyUserIdForDeveloperWallet } from './developerWalletIdentity';
+
+export async function createGiftCardWithDeveloperWallet(params: {
+  activeChain: any;
+  contracts: any;
+  formData: GiftCardData;
+  metadataUri: string;
+  amountWei: string;
+  tokenAddress: string;
+  createAddress: string;
+  developerWallet: any;
+  isConnected: boolean;
+  address?: string;
+  privyUserId?: string;
+  notifyInfo: (message: string) => void;
+  notifyWarning: (message: string) => void;
+}): Promise<GiftCardCreationResult> {
+  const {
+    activeChain,
+    contracts,
+    formData,
+    metadataUri,
+    amountWei,
+    tokenAddress,
+    createAddress,
+    developerWallet,
+    isConnected,
+    address,
+    privyUserId,
+    notifyInfo,
+    notifyWarning
+  } = params;
+
+  const publicClient = createPublicClient({
+    chain: activeChain,
+    transport: http()
+  });
+
+  await assertDeveloperWalletBalance({
+    publicClient,
+    tokenAddress,
+    createAddress,
+    amountWei,
+    currency: formData.currency,
+    amount: formData.amount
+  });
+
+  const privyUserIdForTx = getPrivyUserIdForDeveloperWallet({
+    developerWallet,
+    isConnected,
+    address,
+    privyUserId
+  });
+
+  await approveDeveloperWalletIfNeeded({
+    publicClient,
+    contracts,
+    tokenAddress,
+    createAddress,
+    amountWei,
+    currency: formData.currency,
+    developerWallet,
+    privyUserIdForTx,
+    notifyInfo
+  });
+
+  const txResult = await DeveloperWalletService.sendTransaction({
+    walletId: developerWallet.circle_wallet_id,
+    walletAddress: developerWallet.wallet_address,
+    contractAddress: contracts.contractAddress!,
+    ...getDeveloperWalletCall({ formData, amountWei, tokenAddress, metadataUri }),
+    blockchain: 'ARC-TESTNET',
+    privyUserId: privyUserIdForTx,
+    socialPlatform: developerWallet.social_platform || undefined,
+    socialUserId: developerWallet.social_user_id || undefined
+  });
+
+  if (!txResult.success) {
+    throw new Error(formatDeveloperWalletError(txResult.error || 'Failed to create gift card', formData.currency));
+  }
+
+  const finalTxHash = await resolveCircleTransactionHash({
+    transactionId: txResult.transactionId,
+    txHash: txResult.txHash,
+    currency: formData.currency,
+    notifyInfo,
+    notifyWarning
+  });
+
+  if (!finalTxHash) {
+    throw new Error('Failed to get transaction hash');
+  }
+
+  if (finalTxHash === 'pending' || finalTxHash === txResult.transactionId) {
+    return {
+      tokenId: 'pending',
+      txHash: txResult.transactionId || 'pending'
+    };
+  }
+
+  const receipt = await publicClient.waitForTransactionReceipt({
+    hash: finalTxHash as `0x${string}`
+  }) as any;
+
+  if (receipt.status === 'reverted' || (typeof receipt.status === 'number' && receipt.status === 0)) {
+    throw new Error(`Transaction failed: ERC20 transfer amount exceeds balance or other contract error. Transaction hash: ${finalTxHash}`);
+  }
+
+  return {
+    tokenId: extractTokenIdFromReceipt(receipt, contracts, formData.recipientType),
+    txHash: finalTxHash
+  };
+}

--- a/src/components/gift-card/developerWalletIdentity.ts
+++ b/src/components/gift-card/developerWalletIdentity.ts
@@ -1,0 +1,31 @@
+export function getPrivyUserIdForDeveloperWallet(params: {
+  developerWallet: any;
+  isConnected: boolean;
+  address?: string;
+  privyUserId?: string;
+}) {
+  const { developerWallet, isConnected, address, privyUserId } = params;
+  const walletCreatedWithAddress = developerWallet &&
+    developerWallet.user_id &&
+    developerWallet.user_id.startsWith('0x') &&
+    !developerWallet.privy_user_id &&
+    isConnected &&
+    address &&
+    developerWallet.user_id.toLowerCase() === address.toLowerCase();
+
+  if (walletCreatedWithAddress) {
+    return address.toLowerCase();
+  }
+
+  if (privyUserId) {
+    return privyUserId.startsWith('did:privy:')
+      ? privyUserId.replace('did:privy:', '')
+      : privyUserId;
+  }
+
+  if (isConnected && address) {
+    return address.toLowerCase();
+  }
+
+  return undefined;
+}

--- a/src/components/gift-card/developerWalletTokenOps.ts
+++ b/src/components/gift-card/developerWalletTokenOps.ts
@@ -1,0 +1,83 @@
+import { ERC20ABI } from '@/lib/web3/constants';
+import { DeveloperWalletService } from '@/lib/circle/developerWalletService';
+import type { GiftCardCurrency } from './types';
+import { waitForCircleTransactionCompletion } from './circleTransactionStatus';
+
+export async function assertDeveloperWalletBalance(params: {
+  publicClient: any;
+  tokenAddress: string;
+  createAddress: string;
+  amountWei: string;
+  currency: GiftCardCurrency;
+  amount: string;
+}) {
+  const { publicClient, tokenAddress, createAddress, amountWei, currency, amount } = params;
+  const balance = await publicClient.readContract({
+    address: tokenAddress as `0x${string}`,
+    abi: ERC20ABI,
+    functionName: 'balanceOf',
+    args: [createAddress as `0x${string}`]
+  }) as bigint;
+  const balanceFormatted = (Number(balance) / 1000000).toFixed(6);
+
+  if (BigInt(balance) < BigInt(amountWei)) {
+    throw new Error(`Insufficient ${currency} balance. You have ${balanceFormatted} ${currency}, but need ${amount} ${currency}. Wallet: ${createAddress.slice(0, 6)}...${createAddress.slice(-4)}`);
+  }
+}
+
+export async function approveDeveloperWalletIfNeeded(params: {
+  publicClient: any;
+  contracts: any;
+  tokenAddress: string;
+  createAddress: string;
+  amountWei: string;
+  currency: GiftCardCurrency;
+  developerWallet: any;
+  privyUserIdForTx?: string;
+  notifyInfo: (message: string) => void;
+}) {
+  const {
+    publicClient,
+    contracts,
+    tokenAddress,
+    createAddress,
+    amountWei,
+    currency,
+    developerWallet,
+    privyUserIdForTx,
+    notifyInfo
+  } = params;
+  const spenderAddress = contracts.contractAddress!;
+  const currentAllowance = await publicClient.readContract({
+    address: tokenAddress as `0x${string}`,
+    abi: ERC20ABI,
+    functionName: 'allowance',
+    args: [createAddress as `0x${string}`, spenderAddress as `0x${string}`]
+  }) as bigint;
+
+  if (currentAllowance >= BigInt(amountWei)) {
+    return;
+  }
+
+  notifyInfo(`Approving ${currency} for contract...`);
+
+  const approveTx = await DeveloperWalletService.sendTransaction({
+    walletId: developerWallet.circle_wallet_id,
+    walletAddress: developerWallet.wallet_address,
+    contractAddress: tokenAddress,
+    functionName: 'approve',
+    args: [spenderAddress, BigInt(amountWei)],
+    blockchain: 'ARC-TESTNET',
+    privyUserId: privyUserIdForTx,
+    socialPlatform: developerWallet.social_platform || undefined,
+    socialUserId: developerWallet.social_user_id || undefined
+  });
+
+  if (!approveTx.success) {
+    throw new Error(approveTx.error || 'Approve failed');
+  }
+
+  if (approveTx.transactionId) {
+    await waitForCircleTransactionCompletion(approveTx.transactionId);
+  }
+}

--- a/src/components/gift-card/flowTypes.ts
+++ b/src/components/gift-card/flowTypes.ts
@@ -1,0 +1,4 @@
+export interface GiftCardCreationResult {
+  tokenId: string;
+  txHash: string;
+}

--- a/src/components/gift-card/giftCardDefaults.ts
+++ b/src/components/gift-card/giftCardDefaults.ts
@@ -1,0 +1,24 @@
+import type { GiftCardData } from './types';
+
+export const INITIAL_GIFT_CARD_DATA: GiftCardData = {
+  recipientType: 'address',
+  recipientAddress: '',
+  recipientUsername: '',
+  amount: '1',
+  currency: 'USDC',
+  design: 'pink',
+  message: '',
+  secretMessage: '',
+  hasTimer: false,
+  timerHours: 24,
+  hasPassword: false,
+  password: '',
+  expiryDays: 365,
+  customImage: '',
+  nftCover: ''
+};
+
+export const RESET_GIFT_CARD_DATA: GiftCardData = {
+  ...INITIAL_GIFT_CARD_DATA,
+  expiryDays: 7
+};

--- a/src/components/gift-card/giftCardErrors.ts
+++ b/src/components/gift-card/giftCardErrors.ts
@@ -1,0 +1,116 @@
+import type { GiftCardCurrency } from './types';
+
+export function extractTxHashFromError(errorMessage: string) {
+  return errorMessage.match(/0x[a-fA-F0-9]{64}/)?.[0] ?? null;
+}
+
+export function isUserRejectedError(error: unknown, errorMessage: string) {
+  const errorCode = (error as any)?.code;
+  const normalizedMessage = errorMessage.toLowerCase();
+
+  return errorCode === 4001 ||
+    normalizedMessage.includes('user rejected') ||
+    normalizedMessage.includes('rejected the request') ||
+    normalizedMessage.includes('user denied') ||
+    normalizedMessage.includes('denied transaction');
+}
+
+export type CreateGiftCardErrorPresentation =
+  | { type: 'canceled' }
+  | {
+      type: 'error';
+      message: string;
+      toastTitle: string;
+      toastDescription: string;
+      clearTxHash?: boolean;
+    };
+
+export function classifyCreateGiftCardError(params: {
+  error: unknown;
+  errorMessage: string;
+  currency: GiftCardCurrency;
+  txHash: string | null;
+  isCoinbaseWallet: boolean;
+}): CreateGiftCardErrorPresentation {
+  const { error, errorMessage, currency, txHash, isCoinbaseWallet } = params;
+
+  if (isUserRejectedError(error, errorMessage)) {
+    return { type: 'canceled' };
+  }
+
+  if (errorMessage.includes('invalid chain ID') && isCoinbaseWallet) {
+    return {
+      type: 'error',
+      message: 'Coinbase Wallet has issues with Arc Testnet. Please use MetaMask or Rainbow Wallet to work with Arc Testnet.',
+      toastTitle: 'Error: use MetaMask or Rainbow Wallet',
+      toastDescription: 'Coinbase Wallet is not supported for Arc Testnet',
+      clearTxHash: true
+    };
+  }
+
+  if (errorMessage.includes('ERC20') || errorMessage.includes('transfer amount exceeds balance') || errorMessage.includes('Insufficient') || errorMessage.includes('balance')) {
+    const message = errorMessage.includes('Insufficient')
+      ? errorMessage
+      : `Insufficient ${currency} balance. Please ensure you have enough tokens to create this gift card.`;
+
+    return {
+      type: 'error',
+      message,
+      toastTitle: 'Transaction failed',
+      toastDescription: txHash
+        ? `${message}\nTX: ${txHash.slice(0, 10)}...${txHash.slice(-8)}`
+        : message
+    };
+  }
+
+  if (errorMessage.includes('Transaction failed')) {
+    return {
+      type: 'error',
+      message: errorMessage,
+      toastTitle: 'Transaction failed',
+      toastDescription: errorMessage
+    };
+  }
+
+  if (errorMessage.includes('Vault not configured') || errorMessage.includes('Vault contract')) {
+    return {
+      type: 'error',
+      message: errorMessage,
+      toastTitle: 'Configuration error',
+      toastDescription: errorMessage
+    };
+  }
+
+  if (errorMessage.includes('Invalid username') || errorMessage.includes('username')) {
+    return {
+      type: 'error',
+      message: errorMessage,
+      toastTitle: 'Invalid username',
+      toastDescription: errorMessage
+    };
+  }
+
+  return {
+    type: 'error',
+    message: errorMessage,
+    toastTitle: 'Failed to create gift card',
+    toastDescription: errorMessage
+  };
+}
+
+export function formatDeveloperWalletError(errorMessage: string, currency: GiftCardCurrency, fallback = errorMessage) {
+  if (errorMessage.includes('balance') || errorMessage.includes('insufficient') || errorMessage.includes('ERC20')) {
+    return `Insufficient ${currency} balance. Please ensure you have enough tokens to create this gift card.`;
+  }
+  if (errorMessage.includes('allowance') || errorMessage.includes('approve')) {
+    return 'Token approval failed. Please try again.';
+  }
+  if (errorMessage.includes('Vault not set') || errorMessage.includes('vault')) {
+    return 'Vault contract not configured. Please contact support.';
+  }
+  if (errorMessage.includes('Username required') || errorMessage.includes('username')) {
+    return 'Invalid username. Please check the username and try again.';
+  }
+
+  return fallback;
+}

--- a/src/components/gift-card/giftCardFlow.ts
+++ b/src/components/gift-card/giftCardFlow.ts
@@ -1,0 +1,27 @@
+export type { GiftCardCreationResult } from './flowTypes';
+export {
+  INITIAL_GIFT_CARD_DATA,
+  RESET_GIFT_CARD_DATA
+} from './giftCardDefaults';
+export { buildCreatedCardData } from './createdGiftCardData';
+export {
+  getTokenAddress,
+  normalizeRecipientUsername,
+  resolveCreateWallet,
+  toTokenUnits,
+  validateGiftCardRequest
+} from './giftCardRequest';
+export { createGiftCardWithConnectedWallet } from './connectedWalletFlow';
+export { createGiftCardWithDeveloperWallet } from './developerWalletFlow';
+export {
+  getGiftCardEventType,
+  getRecipientUsernameForStorage,
+  saveCreatedGiftCard
+} from './giftCardPersistence';
+export {
+  classifyCreateGiftCardError,
+  extractTxHashFromError,
+  formatDeveloperWalletError,
+  isUserRejectedError
+} from './giftCardErrors';
+export type { CreateGiftCardErrorPresentation } from './giftCardErrors';

--- a/src/components/gift-card/giftCardPersistence.ts
+++ b/src/components/gift-card/giftCardPersistence.ts
@@ -1,0 +1,70 @@
+import { GiftCardsService } from '@/lib/supabase/giftCards';
+import type { GiftCardData, RecipientType } from './types';
+import type { GiftCardCreationResult } from './flowTypes';
+
+export async function saveCreatedGiftCard(params: {
+  result: GiftCardCreationResult;
+  formData: GiftCardData;
+  activeChainId: number;
+  createAddress: string;
+  metadataUri: string;
+}) {
+  const { result, formData, activeChainId, createAddress, metadataUri } = params;
+  const recipientUsernameForStorage = getRecipientUsernameForStorage(formData);
+  const eventType = getGiftCardEventType(formData.recipientType);
+
+  await GiftCardsService.upsertCard({
+    token_id: result.tokenId,
+    chain_id: activeChainId,
+    sender_address: (createAddress || '').toLowerCase(),
+    recipient_address: formData.recipientType === 'address' ? formData.recipientAddress.toLowerCase() : null,
+    recipient_username: recipientUsernameForStorage,
+    recipient_type: formData.recipientType,
+    amount: formData.amount,
+    currency: formData.currency,
+    message: formData.message,
+    redeemed: false,
+    tx_hash: result.txHash
+  }, activeChainId);
+
+  await GiftCardsService.upsertCardGraph({
+    token_id: result.tokenId,
+    chain_id: activeChainId,
+    sender_address: (createAddress || '').toLowerCase(),
+    recipient_address: formData.recipientType === 'address' ? formData.recipientAddress.toLowerCase() : null,
+    recipient_username: recipientUsernameForStorage,
+    recipient_type: formData.recipientType,
+    amount: formData.amount,
+    currency: formData.currency,
+    message: formData.message,
+    redeemed: false,
+    tx_hash: result.txHash,
+    event_type: eventType,
+    uri: metadataUri,
+    block_number: null,
+    block_timestamp: null
+  }, activeChainId);
+}
+
+export function getGiftCardEventType(recipientType: RecipientType) {
+  switch (recipientType) {
+    case 'twitter':
+      return 'GiftCardCreatedForTwitter';
+    case 'twitch':
+      return 'GiftCardCreatedForTwitch';
+    case 'telegram':
+      return 'GiftCardCreatedForTelegram';
+    case 'tiktok':
+      return 'GiftCardCreatedForTikTok';
+    case 'instagram':
+      return 'GiftCardCreatedForInstagram';
+    case 'address':
+      return 'GiftCardCreated';
+  }
+}
+
+export function getRecipientUsernameForStorage(formData: GiftCardData) {
+  return formData.recipientType === 'address'
+    ? null
+    : formData.recipientUsername.replace(/^@/, '').trim();
+}

--- a/src/components/gift-card/giftCardReceipt.ts
+++ b/src/components/gift-card/giftCardReceipt.ts
@@ -1,0 +1,37 @@
+import type { RecipientType } from './types';
+
+export function extractTokenIdFromReceipt(receipt: any, contracts: any, recipientType: RecipientType) {
+  const transferEventSignature = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+  const zeroAddress = '0x0000000000000000000000000000000000000000';
+  const zeroAddressTopic = `0x${zeroAddress.slice(2).padStart(64, '0')}`;
+  const expectedAddress = getMintingContractAddress(contracts, recipientType);
+  const transferEvent = receipt.logs.find((log: any) =>
+    log.topics[0] === transferEventSignature &&
+    log.topics[1]?.toLowerCase() === zeroAddressTopic.toLowerCase() &&
+    (log.address.toLowerCase() === contracts.contractAddress!.toLowerCase() ||
+      log.address.toLowerCase() === expectedAddress.toLowerCase())
+  );
+
+  if (transferEvent?.topics[3]) {
+    return BigInt(transferEvent.topics[3]).toString();
+  }
+
+  return '1';
+}
+
+function getMintingContractAddress(contracts: any, recipientType: RecipientType) {
+  switch (recipientType) {
+    case 'twitter':
+      return contracts.vaultContract!;
+    case 'twitch':
+      return contracts.twitchVault!;
+    case 'telegram':
+      return contracts.telegramVault!;
+    case 'tiktok':
+      return contracts.tiktokVault!;
+    case 'instagram':
+      return contracts.instagramVault!;
+    case 'address':
+      return contracts.contractAddress!;
+  }
+}

--- a/src/components/gift-card/giftCardRequest.ts
+++ b/src/components/gift-card/giftCardRequest.ts
@@ -1,0 +1,91 @@
+import type { GiftCardCurrency, GiftCardData, RecipientType, WalletSource } from './types';
+
+const RECIPIENT_LABELS: Record<RecipientType, string> = {
+  address: 'recipient',
+  twitter: 'Twitter',
+  twitch: 'Twitch',
+  telegram: 'Telegram',
+  tiktok: 'TikTok',
+  instagram: 'Instagram'
+};
+
+export function resolveCreateWallet(params: {
+  walletSource: WalletSource;
+  isConnected: boolean;
+  address?: string;
+  hasDeveloperWallet: boolean;
+  developerWallet: any;
+}): { createAddress: string; useDeveloperWallet: boolean } | { error: string } {
+  const { walletSource, isConnected, address, hasDeveloperWallet, developerWallet } = params;
+
+  if (!isConnected && !hasDeveloperWallet) {
+    return { error: 'Please connect your wallet first' };
+  }
+
+  if (walletSource === 'developer' && hasDeveloperWallet && developerWallet) {
+    return { createAddress: developerWallet.wallet_address, useDeveloperWallet: true };
+  }
+
+  if (walletSource === 'metamask' && isConnected && address) {
+    return { createAddress: address, useDeveloperWallet: false };
+  }
+
+  if (isConnected && address) {
+    return { createAddress: address, useDeveloperWallet: false };
+  }
+
+  if (hasDeveloperWallet && developerWallet) {
+    return { createAddress: developerWallet.wallet_address, useDeveloperWallet: true };
+  }
+
+  return { error: 'Wallet not connected' };
+}
+
+export function validateGiftCardRequest(formData: GiftCardData, contractAddress?: string | null): string | null {
+  if (!contractAddress) {
+    return 'GiftCard contract is not configured for this network. Set VITE_AVAX_CONTRACT_ADDRESS in .env.';
+  }
+
+  if (formData.recipientType === 'address') {
+    if (!formData.recipientAddress || !formData.recipientAddress.startsWith('0x')) {
+      return 'Please enter a valid recipient address';
+    }
+  } else if (!formData.recipientUsername || formData.recipientUsername.trim() === '') {
+    return `Please enter a ${getRecipientLabel(formData.recipientType)} username`;
+  }
+
+  if (!formData.amount || parseFloat(formData.amount) <= 0) {
+    return 'Please enter a valid amount';
+  }
+
+  return null;
+}
+
+export function getTokenAddress(currency: GiftCardCurrency, contracts: any) {
+  const tokenByCurrency: Record<GiftCardCurrency, string | undefined> = {
+    USDC: contracts.usdc,
+    EURC: contracts.eurc,
+    PATHUSD: contracts.pathusd,
+    ALPHAUSD: contracts.alphausd,
+    BETAUSD: contracts.betausd,
+    THETAUSD: contracts.thetausd
+  };
+
+  return tokenByCurrency[currency] ?? contracts.usdc;
+}
+
+export function toTokenUnits(amount: string) {
+  return (parseFloat(amount) * 1000000).toString();
+}
+
+export function normalizeRecipientUsername(formData: GiftCardData) {
+  if (formData.recipientType === 'address') {
+    return '';
+  }
+
+  return formData.recipientUsername.toLowerCase().replace(/^@/, '').trim();
+}
+
+function getRecipientLabel(recipientType: RecipientType) {
+  return RECIPIENT_LABELS[recipientType];
+}

--- a/src/components/gift-card/recipientOptions.ts
+++ b/src/components/gift-card/recipientOptions.ts
@@ -1,0 +1,16 @@
+import type { RecipientType } from './types';
+
+export type PlatformIconName = RecipientType;
+
+export const RECIPIENT_OPTIONS: Array<{
+  value: RecipientType;
+  label: string;
+  icon: PlatformIconName;
+}> = [
+  { value: 'address', label: 'Wallet address', icon: 'address' },
+  { value: 'twitter', label: 'Twitter', icon: 'twitter' },
+  { value: 'twitch', label: 'Twitch', icon: 'twitch' },
+  { value: 'telegram', label: 'Telegram', icon: 'telegram' },
+  { value: 'tiktok', label: 'TikTok', icon: 'tiktok' },
+  { value: 'instagram', label: 'Instagram', icon: 'instagram' }
+];

--- a/src/components/gift-card/selectedRecipient.ts
+++ b/src/components/gift-card/selectedRecipient.ts
@@ -1,0 +1,74 @@
+import type { GiftCardData, RecipientType, SocialRecipientType } from './types';
+
+type StoredRecipient = {
+  type?: unknown;
+  username?: unknown;
+  address?: unknown;
+  displayName?: unknown;
+};
+
+export interface SelectedRecipientApplication {
+  patch: Pick<GiftCardData, 'recipientType'> & Partial<Pick<GiftCardData, 'recipientAddress' | 'recipientUsername'>>;
+  highlightField: SocialRecipientType | null;
+  toastLabel: string;
+}
+
+const SOCIAL_RECIPIENT_TYPES = new Set<SocialRecipientType>([
+  'twitter',
+  'twitch',
+  'telegram',
+  'tiktok',
+  'instagram'
+]);
+
+function isRecipientType(value: unknown): value is RecipientType {
+  return value === 'address' || SOCIAL_RECIPIENT_TYPES.has(value as SocialRecipientType);
+}
+
+function formatAddress(address: string) {
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+}
+
+export function parseSelectedGiftCardRecipient(rawRecipient: string): SelectedRecipientApplication | null {
+  const recipient = JSON.parse(rawRecipient) as StoredRecipient;
+
+  if (!isRecipientType(recipient.type)) {
+    return null;
+  }
+
+  if (recipient.type === 'address') {
+    if (typeof recipient.address !== 'string') {
+      return null;
+    }
+
+    return {
+      patch: {
+        recipientType: 'address',
+        recipientAddress: recipient.address
+      },
+      highlightField: null,
+      toastLabel: typeof recipient.displayName === 'string'
+        ? recipient.displayName
+        : formatAddress(recipient.address)
+    };
+  }
+
+  if (typeof recipient.username !== 'string') {
+    return null;
+  }
+
+  const username = ['telegram', 'tiktok', 'instagram'].includes(recipient.type)
+    ? recipient.username.replace(/^@/, '')
+    : recipient.username;
+
+  return {
+    patch: {
+      recipientType: recipient.type,
+      recipientUsername: username
+    },
+    highlightField: recipient.type,
+    toastLabel: typeof recipient.displayName === 'string'
+      ? recipient.displayName
+      : recipient.username
+  };
+}

--- a/src/components/gift-card/socialGiftCardAdapters.ts
+++ b/src/components/gift-card/socialGiftCardAdapters.ts
@@ -1,0 +1,91 @@
+import web3Service from '@/lib/web3/web3Service';
+import { createTwitterCardMapping } from '@/lib/twitter';
+import { createTwitchCardMapping } from '@/lib/twitch';
+import { createTelegramCardMapping } from '@/lib/telegram';
+import { createTikTokCardMapping } from '@/lib/tiktok';
+import { createInstagramCardMapping } from '@/lib/instagram';
+import type { GiftCardData, SocialRecipientType } from './types';
+import type { GiftCardCreationResult } from './flowTypes';
+
+interface SocialMappingPayload {
+  tokenId: string;
+  username: string;
+  temporaryOwner: string;
+  senderAddress: string;
+  amount: string;
+  currency: string;
+  message: string;
+  metadataUri: string;
+}
+
+const SOCIAL_GIFT_CARD_ADAPTERS: Record<SocialRecipientType, {
+  createCard: (username: string, formData: GiftCardData, metadataUri: string) => Promise<GiftCardCreationResult>;
+  saveMapping: (payload: SocialMappingPayload) => Promise<unknown>;
+}> = {
+  twitter: {
+    createCard: (username, formData, metadataUri) =>
+      web3Service.createCardForTwitter(username, formData.amount, formData.currency, metadataUri, formData.message),
+    saveMapping: createTwitterCardMapping
+  },
+  twitch: {
+    createCard: (username, formData, metadataUri) =>
+      web3Service.createCardForTwitch(username, formData.amount, formData.currency, metadataUri, formData.message),
+    saveMapping: createTwitchCardMapping
+  },
+  telegram: {
+    createCard: (username, formData, metadataUri) =>
+      web3Service.createCardForTelegram(username, formData.amount, formData.currency, metadataUri, formData.message),
+    saveMapping: createTelegramCardMapping
+  },
+  tiktok: {
+    createCard: (username, formData, metadataUri) =>
+      web3Service.createCardForTikTok(username, formData.amount, formData.currency, metadataUri, formData.message),
+    saveMapping: createTikTokCardMapping
+  },
+  instagram: {
+    createCard: (username, formData, metadataUri) =>
+      web3Service.createCardForInstagram(username, formData.amount, formData.currency, metadataUri, formData.message),
+    saveMapping: createInstagramCardMapping
+  }
+};
+
+export async function createSocialGiftCard(params: {
+  formData: GiftCardData;
+  normalizedUsername: string;
+  metadataUri: string;
+}): Promise<GiftCardCreationResult> {
+  const { formData, normalizedUsername, metadataUri } = params;
+  if (formData.recipientType === 'address') {
+    throw new Error('Address recipients are not social gift cards');
+  }
+
+  return SOCIAL_GIFT_CARD_ADAPTERS[formData.recipientType].createCard(normalizedUsername, formData, metadataUri);
+}
+
+export async function saveSocialCardMapping(params: {
+  formData: GiftCardData;
+  result: GiftCardCreationResult;
+  normalizedUsername: string;
+  createAddress: string;
+  metadataUri: string;
+}) {
+  const { formData, result, normalizedUsername, createAddress, metadataUri } = params;
+  if (formData.recipientType === 'address') {
+    return;
+  }
+
+  try {
+    await SOCIAL_GIFT_CARD_ADAPTERS[formData.recipientType].saveMapping({
+      tokenId: result.tokenId,
+      username: normalizedUsername,
+      temporaryOwner: '',
+      senderAddress: createAddress,
+      amount: formData.amount,
+      currency: formData.currency,
+      message: formData.message,
+      metadataUri
+    });
+  } catch (error) {
+    console.error(`Error saving ${formData.recipientType} card metadata:`, error);
+  }
+}

--- a/src/components/gift-card/types.ts
+++ b/src/components/gift-card/types.ts
@@ -1,0 +1,25 @@
+export type RecipientType = 'address' | 'twitter' | 'twitch' | 'telegram' | 'tiktok' | 'instagram';
+
+export type SocialRecipientType = Exclude<RecipientType, 'address'>;
+
+export type GiftCardCurrency = 'USDC' | 'EURC' | 'PATHUSD' | 'ALPHAUSD' | 'BETAUSD' | 'THETAUSD';
+
+export interface GiftCardData {
+  recipientType: RecipientType;
+  recipientAddress: string;
+  recipientUsername: string;
+  amount: string;
+  currency: GiftCardCurrency;
+  design: 'pink' | 'blue' | 'green' | 'custom';
+  message: string;
+  secretMessage: string;
+  hasTimer: boolean;
+  timerHours: number;
+  hasPassword: boolean;
+  password: string;
+  expiryDays: number;
+  customImage: string;
+  nftCover: string;
+}
+
+export type WalletSource = 'metamask' | 'developer';

--- a/src/components/gift-card/useDeveloperWalletLookup.ts
+++ b/src/components/gift-card/useDeveloperWalletLookup.ts
@@ -1,0 +1,159 @@
+import { useEffect, useState } from 'react';
+import { DeveloperWalletService } from '@/lib/circle/developerWalletService';
+import type { SocialRecipientType, WalletSource } from './types';
+
+const BLOCKCHAIN = 'ARC-TESTNET';
+const SOCIAL_PLATFORMS: SocialRecipientType[] = ['twitter', 'twitch', 'telegram', 'tiktok', 'instagram'];
+
+interface UseDeveloperWalletLookupParams {
+  isConnected: boolean;
+  authenticated: boolean;
+  address?: string;
+  privyUser: any;
+}
+
+export function useDeveloperWalletLookup({
+  isConnected,
+  authenticated,
+  address,
+  privyUser
+}: UseDeveloperWalletLookupParams) {
+  const [hasDeveloperWallet, setHasDeveloperWallet] = useState(false);
+  const [developerWallet, setDeveloperWallet] = useState<any>(null);
+  const [checkingWallet, setCheckingWallet] = useState(true);
+  const [walletSource, setWalletSource] = useState<WalletSource>('metamask');
+
+  useEffect(() => {
+    let canceled = false;
+
+    async function checkDeveloperWallet() {
+      if (!isConnected && (!authenticated || !privyUser)) {
+        if (!canceled) {
+          setHasDeveloperWallet(false);
+          setDeveloperWallet(null);
+          setCheckingWallet(false);
+        }
+        return;
+      }
+
+      try {
+        setCheckingWallet(true);
+        const foundWallet =
+          await findWalletByConnectedAddress(isConnected, address) ??
+          await findWalletBySocialAccounts(privyUser) ??
+          await findWalletByPrivyUserId(privyUser?.id);
+
+        if (canceled) {
+          return;
+        }
+
+        setHasDeveloperWallet(Boolean(foundWallet));
+        setDeveloperWallet(foundWallet);
+
+        if (foundWallet) {
+          setWalletSource(isConnected ? 'metamask' : 'developer');
+        } else if (isConnected) {
+          setWalletSource('metamask');
+        }
+      } catch (error) {
+        console.error('Error checking social wallet:', error);
+        if (!canceled) {
+          setHasDeveloperWallet(false);
+          setDeveloperWallet(null);
+          if (isConnected) {
+            setWalletSource('metamask');
+          }
+        }
+      } finally {
+        if (!canceled) {
+          setCheckingWallet(false);
+        }
+      }
+    }
+
+    checkDeveloperWallet();
+
+    return () => {
+      canceled = true;
+    };
+  }, [isConnected, authenticated, privyUser, address]);
+
+  return {
+    hasDeveloperWallet,
+    developerWallet,
+    checkingWallet,
+    walletSource,
+    setWalletSource
+  };
+}
+
+async function findWalletByConnectedAddress(isConnected: boolean, address?: string) {
+  if (!isConnected || !address) {
+    return null;
+  }
+
+  try {
+    return findArcWallet(await DeveloperWalletService.getWallets(address.toLowerCase().trim()));
+  } catch (error) {
+    return null;
+  }
+}
+
+async function findWalletBySocialAccounts(privyUser: any) {
+  if (!privyUser) {
+    return null;
+  }
+
+  for (const platform of SOCIAL_PLATFORMS) {
+    const socialUserId = getSocialUserId(privyUser, platform);
+    if (!socialUserId) {
+      continue;
+    }
+
+    const wallet = await DeveloperWalletService.getWalletBySocial(platform, socialUserId, BLOCKCHAIN);
+    if (wallet) {
+      return wallet;
+    }
+  }
+
+  return null;
+}
+
+async function findWalletByPrivyUserId(privyUserId?: string) {
+  if (!privyUserId) {
+    return null;
+  }
+
+  try {
+    const normalizedPrivyUserId = privyUserId.startsWith('did:privy:')
+      ? privyUserId.replace('did:privy:', '')
+      : privyUserId;
+    return findArcWallet(await DeveloperWalletService.getWallets(normalizedPrivyUserId));
+  } catch (error) {
+    return null;
+  }
+}
+
+function findArcWallet(wallets: any[]) {
+  return wallets.find((wallet: any) => wallet.blockchain === BLOCKCHAIN) ?? wallets[0] ?? null;
+}
+
+function getSocialUserId(privyUser: any, platform: SocialRecipientType) {
+  if (platform === 'twitter' && privyUser.twitter) {
+    return privyUser.twitter.subject;
+  }
+  if (platform === 'twitch' && privyUser.twitch) {
+    return privyUser.twitch.subject;
+  }
+  if (platform === 'telegram' && privyUser.telegram) {
+    return privyUser.telegram.telegramUserId || privyUser.telegram.subject;
+  }
+  if (platform === 'tiktok' && privyUser.tiktok) {
+    return privyUser.tiktok.subject;
+  }
+  if (platform === 'instagram' && privyUser.instagram) {
+    return privyUser.instagram.subject;
+  }
+
+  return null;
+}

--- a/src/components/gift-card/walletName.ts
+++ b/src/components/gift-card/walletName.ts
@@ -1,0 +1,96 @@
+const DEFAULT_WALLET_NAME = 'Web3 Wallet';
+
+function getInjectedWalletName(): string {
+  if (typeof window === 'undefined' || !window.ethereum) {
+    return DEFAULT_WALLET_NAME;
+  }
+
+  const ethereum = window.ethereum as any;
+
+  if (ethereum.isRabby === true) {
+    return 'Rabby Wallet';
+  }
+
+  if (ethereum.isMetaMask === true && ethereum.isRabby !== true) {
+    return 'MetaMask';
+  }
+
+  if (ethereum.isMetaMask === true) {
+    return 'MetaMask';
+  }
+  if (ethereum.isCoinbaseWallet) {
+    return 'Coinbase Wallet';
+  }
+  if (ethereum.isTrust) {
+    return 'Trust Wallet';
+  }
+  if (ethereum.isBraveWallet) {
+    return 'Brave Wallet';
+  }
+  if (ethereum.isTokenPocket) {
+    return 'TokenPocket';
+  }
+  if (ethereum.isImToken) {
+    return 'imToken';
+  }
+  if (ethereum.isOKExWallet) {
+    return 'OKX Wallet';
+  }
+  if (ethereum.isBitKeep) {
+    return 'BitKeep';
+  }
+  if (ethereum.isFrame) {
+    return 'Frame';
+  }
+  if (ethereum.isPhantom) {
+    return 'Phantom';
+  }
+  if (ethereum.isAvalanche) {
+    return 'Avalanche Wallet';
+  }
+  if (ethereum.isZeppelin) {
+    return 'Zeppelin';
+  }
+  if (ethereum.isRainbow) {
+    return 'Rainbow Wallet';
+  }
+
+  if (ethereum.providerName && !ethereum.isMetaMask && !ethereum.isRabby) {
+    const providerName = String(ethereum.providerName).toLowerCase().trim();
+    if (providerName === 'rabby' || providerName === 'rabby wallet') {
+      return 'Rabby Wallet';
+    }
+    if (providerName === 'metamask') {
+      return 'MetaMask';
+    }
+  }
+
+  return DEFAULT_WALLET_NAME;
+}
+
+export function detectWalletName(connectorName?: string | null): string {
+  if (connectorName) {
+    const normalizedName = connectorName.toLowerCase();
+    if (normalizedName.includes('rabby')) {
+      return 'Rabby Wallet';
+    }
+    if (normalizedName.includes('metamask')) {
+      return 'MetaMask';
+    }
+    if (normalizedName.includes('coinbase')) {
+      return 'Coinbase Wallet';
+    }
+    if (normalizedName.includes('trust')) {
+      return 'Trust Wallet';
+    }
+    if (normalizedName.includes('rainbow')) {
+      return 'Rainbow Wallet';
+    }
+
+    return connectorName;
+  }
+
+  return getInjectedWalletName();
+}
+
+export { DEFAULT_WALLET_NAME };

--- a/src/components/landing-page/colophon-section.tsx
+++ b/src/components/landing-page/colophon-section.tsx
@@ -88,7 +88,6 @@ export function ColophonSection() {
         <div className="col-span-1">
           <h4 className="font-mono text-[9px] uppercase tracking-[0.2em] text-gray-500 mb-4">Stack</h4>
           <ul className="space-y-2">
-            <li className="font-mono text-xs text-gray-600">Circle SDK</li>
             <li className="font-mono text-xs text-gray-600">Reclaim Protocol</li>
           </ul>
         </div>

--- a/src/lib/aimlapiService.ts
+++ b/src/lib/aimlapiService.ts
@@ -1,35 +1,5 @@
-export interface AIMLAPIRequest {
-  model: string;
-  messages: Array<{
-    role: 'system' | 'user' | 'assistant';
-    content: string;
-  }>;
-  temperature?: number;
-  max_tokens?: number;
-}
-
-export interface AIMLAPIResponse {
-  id: string;
-  object: string;
-  created: number;
-  model: string;
-  choices: Array<{
-    index: number;
-    message: {
-      role: string;
-      content: string;
-    };
-    finish_reason: string;
-  }>;
-  usage: {
-    prompt_tokens: number;
-    completion_tokens: number;
-    total_tokens: number;
-  };
-}
-
 export interface ParsedPaymentCommand {
-  recipientName: string;
+  recipientName: string | null;
   amount: number;
   currency: 'USDC' | 'EURC' | 'USYC';
   message?: string;
@@ -37,65 +7,19 @@ export interface ParsedPaymentCommand {
 }
 
 export class AIMLAPIService {
-  private apiKey: string;
-  private baseUrl = 'https://api.aimlapi.com/v1/chat/completions';
-  private openAIApiKey: string;
-  private openAIBaseUrl = 'https://api.openai.com/v1/chat/completions';
+  private parseEndpoint: string;
 
   constructor() {
-    this.apiKey = import.meta.env.VITE_AIMLAPI_API_KEY || '7ed88c0107294ab280db8ad2ddfbc485';
-    const env = import.meta.env as Record<string, string | undefined>;
-    this.openAIApiKey = import.meta.env.VITE_OPENAI_API_KEY || env?.OPENAI_API_KEY || '';
+    this.parseEndpoint = (import.meta.env.VITE_AI_PARSE_FUNCTION_URL || '').trim();
   }
 
-  private async requestCompletion(
-    provider: 'aimlapi' | 'openai',
-    systemPrompt: string,
-    userPrompt: string
-  ): Promise<string> {
-    const isAiml = provider === 'aimlapi';
-    const baseUrl = isAiml ? this.baseUrl : this.openAIBaseUrl;
-    const apiKey = isAiml ? this.apiKey : this.openAIApiKey;
-    const model = isAiml ? 'deepseek/deepseek-chat' : 'gpt-4o-mini';
-
-    if (!apiKey) {
+  private getParseEndpoint(): string {
+    if (!this.parseEndpoint) {
       throw new Error(
-        `API key for ${provider.toUpperCase()} is not configured.`
+        'AI command parsing requires a backend endpoint. Set VITE_AI_PARSE_FUNCTION_URL to a server route that keeps provider API keys off the client.'
       );
     }
-
-    const response = await fetch(baseUrl, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model,
-        messages: [
-          { role: 'system', content: systemPrompt },
-          { role: 'user', content: userPrompt },
-        ],
-        temperature: 0.3,
-        max_tokens: 500,
-      }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`${provider.toUpperCase()} API error: ${response.status} - ${errorText}`);
-    }
-
-    const data: AIMLAPIResponse = await response.json();
-    const content = data.choices[0]?.message?.content || '';
-
-    if (!content.trim()) {
-      throw new Error(`${provider.toUpperCase()} API returned empty response`);
-    }
-
-    console.log(`AI provider used: ${provider}`);
-
-    return content;
+    return this.parseEndpoint;
   }
 
   async parsePaymentCommand(
@@ -103,53 +27,25 @@ export class AIMLAPIService {
     contacts: Array<{ name: string; wallet: string }>
   ): Promise<ParsedPaymentCommand | null> {
     const contactsList = contacts.map(c => `${c.name}: ${c.wallet}`).join('\n');
-    
-    const systemPrompt = `You are an AI agent for processing voice commands for creating gift cards. Your task is to extract from the user's command: 1. Recipient name (find it in the contacts list), 2. Amount in dollars, 3. Currency (USDC, EURC, or USYC - default USDC), 4. Occasion/reason (e.g., "for birthday", "for Christmas", "congratulations", etc.), 5. Message (if specified). User's contacts list: ${contactsList || 'List is empty'}. Reply ONLY with a valid JSON object in the format: {"recipientName": "name from contacts list or null if not found", "amount": number, "currency": "USDC", "EURC", or "USYC", "message": "message text or empty string", "occasion": "occasion or empty string"}. If the recipient name is not found in the contacts list, set recipientName to null. You must return only JSON, without any additional text.`;
-
-    const userPrompt = `Process this command: "${userCommand}"`;
 
     try {
-      let content: string;
-      try {
-        content = await this.requestCompletion('aimlapi', systemPrompt, userPrompt);
-      } catch (primaryError) {
-        console.error('Error calling AI/ML API (AIML):', primaryError);
+      const response = await fetch(this.getParseEndpoint(), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          userCommand,
+          contacts,
+          contactsList,
+        }),
+      });
 
-        if (!this.openAIApiKey) {
-          throw primaryError;
-        }
-
-        console.warn('Falling back to OpenAI API...');
-        content = await this.requestCompletion('openai', systemPrompt, userPrompt);
+      if (!response.ok) {
+        throw new Error(`AI command parser returned HTTP ${response.status}: ${await response.text()}`);
       }
 
-      console.log('AI API response content:', content);
-      
-      try {
-        let jsonString = content.trim();
-        
-        if (!jsonString.startsWith('{')) {
-          const jsonMatch = jsonString.match(/\{[\s\S]*\}/);
-          if (jsonMatch) {
-            jsonString = jsonMatch[0];
-          } else {
-            throw new Error('No JSON found in response');
-          }
-        }
-        
-        const parsed = JSON.parse(jsonString) as ParsedPaymentCommand;
-        
-        console.log('Parsed JSON:', parsed);
-        
-        if (parsed.recipientName === null) {
-          return null;
-        }
-        
-        return parsed;
-      } catch (parseError) {
-        console.error('Error parsing AI response:', parseError, 'Content:', content);
-        return null;
-      }
+      const parsed = (await response.json()) as ParsedPaymentCommand | null;
+      if (!parsed?.recipientName) return null;
+      return parsed;
     } catch (error) {
       console.error('Error calling AI/ML API:', error);
       throw error;

--- a/src/lib/elevenlabs/elevenlabsService.ts
+++ b/src/lib/elevenlabs/elevenlabsService.ts
@@ -12,10 +12,19 @@ export interface TranscriptionResult {
 }
 
 export class ElevenLabsService {
-  private apiKey: string;
+  private transcribeEndpoint: string;
 
   constructor() {
-    this.apiKey = import.meta.env.VITE_ELEVENLABS_API_KEY || 'sk_e93b8144735060aaf5df2e8fd49e75d51fb6571a05663001';
+    this.transcribeEndpoint = (import.meta.env.VITE_AUDIO_TRANSCRIBE_FUNCTION_URL || '').trim();
+  }
+
+  private getTranscribeEndpoint(): string {
+    if (!this.transcribeEndpoint) {
+      throw new Error(
+        'Audio transcription requires a backend endpoint. Set VITE_AUDIO_TRANSCRIBE_FUNCTION_URL to a server route that keeps ElevenLabs credentials off the client.'
+      );
+    }
+    return this.transcribeEndpoint;
   }
 
   async transcribeAudio(audioBlob: Blob): Promise<TranscriptionResult> {
@@ -29,17 +38,14 @@ export class ElevenLabsService {
     formData.append('language_code', 'en');
 
     try {
-      const response = await fetch('https://api.elevenlabs.io/v1/speech-to-text', {
+      const response = await fetch(this.getTranscribeEndpoint(), {
         method: 'POST',
-        headers: {
-          'xi-api-key': this.apiKey,
-        },
         body: formData,
       });
 
       if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(`ElevenLabs API error: ${response.status} - ${errorText}`);
+        throw new Error(`Audio transcription error: ${response.status} - ${errorText}`);
       }
 
       const data = await response.json();

--- a/src/lib/pinata/pinataService.ts
+++ b/src/lib/pinata/pinataService.ts
@@ -1,5 +1,7 @@
 /// <reference types="vite/client" />
 
+import { supabase } from '@/lib/supabase/client';
+
 export interface PinataMetadata {
   name: string;
   description: string;
@@ -11,66 +13,69 @@ export interface PinataMetadata {
 }
 
 export class PinataService {
-  private apiKey: string;
-  private secretKey: string;
+  private uploadEndpoint: string;
 
   constructor() {
-    // Load environment variables from Vite
-    this.apiKey = import.meta.env.VITE_PINATA_API_KEY || '8edb81ceca8d03963ee4';
-    this.secretKey = import.meta.env.VITE_PINATA_SECRET_API_KEY || '1c0a0f721f587b961ff33da1636746ad086d206638ae7302327dc7b339de0a89';
+    this.uploadEndpoint = (import.meta.env.VITE_PINATA_UPLOAD_FUNCTION_URL || '').trim();
+  }
+
+  private ensureEndpoint(): string {
+    if (!this.uploadEndpoint) {
+      throw new Error(
+        'Pinata uploads require a backend endpoint. Set VITE_PINATA_UPLOAD_FUNCTION_URL to a server route that keeps Pinata credentials off the client.'
+      );
+    }
+    return this.uploadEndpoint;
+  }
+
+  private async getAuthHeaders(): Promise<Record<string, string>> {
+    const { data } = await supabase.auth.getSession();
+    const token = data.session?.access_token;
+    return token ? { Authorization: `Bearer ${token}` } : {};
   }
 
   async uploadImage(imageBlob: Blob): Promise<string> {
-    try {
-      if (!this.apiKey || !this.secretKey) throw new Error('Pinata API keys are not configured. Please check your .env file.');
-      if (typeof this.apiKey !== 'string' || typeof this.secretKey !== 'string') throw new Error('Pinata API keys must be strings.');
-      const formData = new FormData();
-      formData.append('file', imageBlob);
+    const formData = new FormData();
+    formData.append('file', imageBlob);
 
-      const response = await fetch('https://api.pinata.cloud/pinning/pinFileToIPFS', {
-        method: 'POST',
-        headers: {
-          'pinata_api_key': this.apiKey,
-          'pinata_secret_api_key': this.secretKey,
-        },
-        body: formData,
-      });
+    const response = await fetch(`${this.ensureEndpoint().replace(/\/$/, '')}/image`, {
+      method: 'POST',
+      headers: await this.getAuthHeaders(),
+      body: formData,
+    });
 
-      if (!response.ok) throw new Error(`Failed to upload image to Pinata: ${response.status} ${await response.text()}`);
+    if (!response.ok) throw new Error(`Failed to upload image: ${response.status} ${await response.text()}`);
 
-      const result = await response.json();
+    const result = await response.json();
+    const uri = result.uri || result.imageUri || (result.IpfsHash ? `ipfs://${result.IpfsHash}` : '');
 
-      return `ipfs://${result.IpfsHash}`;
-    } catch (error) {
-      throw error;
+    if (!uri) {
+      throw new Error('Pinata upload endpoint did not return an IPFS URI.');
     }
+
+    return uri;
   }
 
   async uploadMetadata(metadata: PinataMetadata): Promise<string> {
-    try {
-      const response = await fetch('https://api.pinata.cloud/pinning/pinJSONToIPFS', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'pinata_api_key': this.apiKey,
-          'pinata_secret_api_key': this.secretKey,
-        },
-        body: JSON.stringify({
-          pinataMetadata: {
-            name: metadata.name,
-          },
-          pinataContent: metadata,
-        }),
-      });
+    const response = await fetch(`${this.ensureEndpoint().replace(/\/$/, '')}/metadata`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(await this.getAuthHeaders()),
+      },
+      body: JSON.stringify({ metadata }),
+    });
 
-      if (!response.ok) throw new Error(`Failed to upload metadata to Pinata: ${response.status} ${await response.text()}`);
+    if (!response.ok) throw new Error(`Failed to upload metadata: ${response.status} ${await response.text()}`);
 
-      const result = await response.json();
+    const result = await response.json();
+    const uri = result.uri || result.metadataUri || (result.IpfsHash ? `ipfs://${result.IpfsHash}` : '');
 
-      return `ipfs://${result.IpfsHash}`;
-    } catch (error) {
-      throw error;
+    if (!uri) {
+      throw new Error('Pinata metadata endpoint did not return an IPFS URI.');
     }
+
+    return uri;
   }
 
   async createGiftCardNFT(
@@ -80,35 +85,31 @@ export class PinataService {
     design: string,
     imageBlob: Blob
   ): Promise<string> {
-    try {
-      const imageUri = await this.uploadImage(imageBlob);
-      const metadata: PinataMetadata = {
-        name: `Gift Card - ${amount} ${currency}`,
-        description: `A digital gift card worth ${amount} ${currency}. ${message}`,
-        image: imageUri,
-        attributes: [
-          {
-            trait_type: 'Amount',
-            value: amount,
-          },
-          {
-            trait_type: 'Currency',
-            value: currency,
-          },
-          {
-            trait_type: 'Design',
-            value: design,
-          },
-          {
-            trait_type: 'Message',
-            value: message,
-          },
-        ],
-      };
-      return this.uploadMetadata(metadata);
-    } catch (error) {
-      throw error;
-    }
+    const imageUri = await this.uploadImage(imageBlob);
+    const metadata: PinataMetadata = {
+      name: `Gift Card - ${amount} ${currency}`,
+      description: `A digital gift card worth ${amount} ${currency}. ${message}`,
+      image: imageUri,
+      attributes: [
+        {
+          trait_type: 'Amount',
+          value: amount,
+        },
+        {
+          trait_type: 'Currency',
+          value: currency,
+        },
+        {
+          trait_type: 'Design',
+          value: design,
+        },
+        {
+          trait_type: 'Message',
+          value: message,
+        },
+      ],
+    };
+    return this.uploadMetadata(metadata);
   }
 }
 

--- a/src/lib/supabase/giftCards.ts
+++ b/src/lib/supabase/giftCards.ts
@@ -96,7 +96,8 @@ export class GiftCardsService {
       let q = supabase
         .from('gift_cards')
         .select('*')
-        .eq('recipient_address', recipientAddress.toLowerCase());
+        .eq('recipient_address', recipientAddress.toLowerCase())
+        .eq('recipient_type', 'address');
       if (chainId != null) q = q.eq('chain_id', chainId);
       let { data, error } = await q.order('created_at', { ascending: false });
       if (error && isChainIdSchemaError(error) && chainId != null) {
@@ -104,6 +105,7 @@ export class GiftCardsService {
           .from('gift_cards')
           .select('*')
           .eq('recipient_address', recipientAddress.toLowerCase())
+          .eq('recipient_type', 'address')
           .order('created_at', { ascending: false });
         data = r.data;
         error = r.error;
@@ -258,13 +260,14 @@ export class GiftCardsService {
     }
   }
 
-  /** Cards where `recipient_address` is this wallet (incl. claimed social if row still has platform `recipient_type`). */
+  /** Received cards (address recipient) from gift_cards_graph. */
   static async getGraphCardsByRecipientAddress(recipientAddress: string, chainId?: number): Promise<GiftCardRecord[]> {
     try {
       let q = supabase
         .from('gift_cards_graph')
         .select('*')
-        .eq('recipient_address', recipientAddress.toLowerCase());
+        .eq('recipient_address', recipientAddress.toLowerCase())
+        .eq('recipient_type', 'address');
       if (chainId != null) q = q.eq('chain_id', chainId);
       let { data, error } = await q.order('created_at', { ascending: false });
       if (error && isChainIdSchemaError(error) && chainId != null) {
@@ -272,6 +275,7 @@ export class GiftCardsService {
           .from('gift_cards_graph')
           .select('*')
           .eq('recipient_address', recipientAddress.toLowerCase())
+          .eq('recipient_type', 'address')
           .order('created_at', { ascending: false });
         data = r.data;
         error = r.error;

--- a/src/lib/supabase/giftCards.ts
+++ b/src/lib/supabase/giftCards.ts
@@ -91,13 +91,13 @@ export class GiftCardsService {
     }
   }
 
+  /** Received cards owned by wallet address (includes social cards after claim). */
   static async getCardsByRecipientAddress(recipientAddress: string, chainId?: number): Promise<GiftCardRecord[]> {
     try {
       let q = supabase
         .from('gift_cards')
         .select('*')
-        .eq('recipient_address', recipientAddress.toLowerCase())
-        .eq('recipient_type', 'address');
+        .eq('recipient_address', recipientAddress.toLowerCase());
       if (chainId != null) q = q.eq('chain_id', chainId);
       let { data, error } = await q.order('created_at', { ascending: false });
       if (error && isChainIdSchemaError(error) && chainId != null) {
@@ -105,7 +105,6 @@ export class GiftCardsService {
           .from('gift_cards')
           .select('*')
           .eq('recipient_address', recipientAddress.toLowerCase())
-          .eq('recipient_type', 'address')
           .order('created_at', { ascending: false });
         data = r.data;
         error = r.error;
@@ -260,14 +259,13 @@ export class GiftCardsService {
     }
   }
 
-  /** Received cards (address recipient) from gift_cards_graph. */
+  /** Received cards owned by wallet address from gift_cards_graph (includes social cards after claim). */
   static async getGraphCardsByRecipientAddress(recipientAddress: string, chainId?: number): Promise<GiftCardRecord[]> {
     try {
       let q = supabase
         .from('gift_cards_graph')
         .select('*')
-        .eq('recipient_address', recipientAddress.toLowerCase())
-        .eq('recipient_type', 'address');
+        .eq('recipient_address', recipientAddress.toLowerCase());
       if (chainId != null) q = q.eq('chain_id', chainId);
       let { data, error } = await q.order('created_at', { ascending: false });
       if (error && isChainIdSchemaError(error) && chainId != null) {
@@ -275,7 +273,6 @@ export class GiftCardsService {
           .from('gift_cards_graph')
           .select('*')
           .eq('recipient_address', recipientAddress.toLowerCase())
-          .eq('recipient_type', 'address')
           .order('created_at', { ascending: false });
         data = r.data;
         error = r.error;

--- a/src/lib/tokenAmount.ts
+++ b/src/lib/tokenAmount.ts
@@ -1,0 +1,50 @@
+/** USDC / EURC and other supported stablecoins use 6 decimals in this app. */
+export const STABLECOIN_DECIMALS = 6;
+export const MICRO = 10 ** STABLECOIN_DECIMALS;
+
+export type TokenAmountUnit = 'human' | 'micro';
+
+export function normalizeTokenAmount(
+  raw: string | number | bigint,
+  options: { unit?: TokenAmountUnit } = {}
+): number {
+  const unit = options.unit ?? 'human';
+  if (raw === null || raw === undefined) return 0;
+
+  const str = typeof raw === 'bigint' ? raw.toString() : String(raw).trim();
+  if (!str) return 0;
+
+  if (str.includes('.')) {
+    const n = parseFloat(str);
+    return Number.isFinite(n) ? n : 0;
+  }
+
+  if (!/^-?\d+$/.test(str)) {
+    const n = parseFloat(str);
+    return Number.isFinite(n) ? n : 0;
+  }
+
+  const asBig = BigInt(str);
+  if (unit === 'micro') {
+    return Number(asBig) / MICRO;
+  }
+
+  const n = Number(asBig);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function formatDisplayAmount(n: string | number, decimals = 2): string {
+  const num = typeof n === 'string' ? parseFloat(n) : n;
+  if (!Number.isFinite(num)) return (0).toFixed(decimals);
+  return num.toFixed(decimals);
+}
+
+export function formatTokenAmountString(
+  raw: string | number | bigint,
+  options: { unit?: TokenAmountUnit } = {}
+): string {
+  const n = normalizeTokenAmount(raw, options);
+  if (n === 0) return '0';
+  const fixed = n.toFixed(STABLECOIN_DECIMALS);
+  return fixed.replace(/\.?0+$/, '');
+}

--- a/src/pages/BlogPostRoute.tsx
+++ b/src/pages/BlogPostRoute.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { Calendar, ArrowLeft, Tag, Clock } from 'lucide-react';
 import { TransformWrapper, TransformComponent } from 'react-zoom-pan-pinch';
 import { VerificationInfographic } from '@/components/figma/VerificationInfographic';
@@ -26,12 +26,12 @@ const PAYMENTS_SEND_PREVIEW_FALLBACK: SendPaymentPreviewValues = {
   amount: '100',
   token: 'USDC',
   platform: 'twitter',
-  username: 'Arc',
+  username: 'arc',
   balance: '362.347036',
-  suggestionLabel: 'Arc @Arc',
+  suggestionLabel: 'Arc @arc',
 };
 
-const BLOG_PREVIEW_USERNAME = 'Arc';
+const BLOG_PREVIEW_USERNAME = 'arc';
 
 interface BlogPost {
   slug: string;
@@ -57,7 +57,7 @@ interface BlogSection {
 interface BlogImage {
   id: string;
   src?: string;
-  componentId?: 'verification-infographic' | 'zktls-infographic' | 'zktls-Architecture-infographic' | 'privy-oauth-infographic' | 'payments-send-embed' | 'payments-receive-embed' | 'gift-card-create-embed' | 'internal-wallet-dashboard-embed' | 'internal-wallet-create-embed';
+  componentId?: 'verification-infographic' | 'zktls-infographic' | 'zktls-architecture-infographic' | 'privy-oauth-infographic' | 'payments-send-embed' | 'payments-receive-embed' | 'gift-card-create-embed' | 'internal-wallet-dashboard-embed' | 'internal-wallet-create-embed';
   alt: string;
   caption: string;
 }
@@ -171,9 +171,9 @@ const blogPosts: Record<string, BlogPost> = {
         caption: ''
       },
       {
-        id: 'zktls-Architecture',
-        componentId: 'zktls-Architecture-infographic',
-        alt: 'zkTLS Architecture: device, attestor, platform, contract, chain',
+        id: 'zktls-architecture',
+        componentId: 'zktls-architecture-infographic',
+        alt: 'zkTLS architecture: device, attestor, platform, contract, chain',
         caption: ''
       },
   
@@ -207,12 +207,12 @@ const blogPosts: Record<string, BlogPost> = {
         imageId: 'zktls-flow'
       },
       {
-        id: 'Architecture',
+        id: 'architecture',
         title: 'Architecture',
         paragraphs: [
           'Path: your device to the attestor (relay and signer) to the social platform. The attestor validates the TLS session and signs the claim. You submit the claim on-chain; the contract checks the signature and sends funds to the recipient wallet.'
         ],
-        imageId: 'zktls-Architecture'
+        imageId: 'zktls-architecture'
       },
       {
         id: 'how-it-works',
@@ -351,7 +351,7 @@ const blogPosts: Record<string, BlogPost> = {
         paragraphs: [],
         bullets: [
           'Wallet: MetaMask, Rabby, or Circle wallet',
-          'Tokens: USDC or EURC on Arc',
+          'Tokens: USDC or EURC on ARC Testnet',
           'A supported social account (if sending or receiving by username)'
         ]
       },
@@ -361,7 +361,7 @@ const blogPosts: Record<string, BlogPost> = {
         paragraphs: [],
         bullets: [
           'No card: log in with the account that should receive it.',
-          'Claim errors: stay on Arc and keep a little gas for fees.',
+          'Claim errors: stay on ARC Testnet and keep a little gas for fees.',
           'Wrong person: on-chain sends cannot be undone. Check the address or username before you confirm.',
           'Lost password: only whoever set it can help; we do not have it.'
         ]
@@ -370,7 +370,7 @@ const blogPosts: Record<string, BlogPost> = {
         id: 'security',
         title: 'Security notes',
         paragraphs: [
-          'Smart contracts on Arc hold the rules. We do not store private keys.',
+          'Smart contracts on ARC Testnet hold the rules. We do not store private keys.',
           'With Circle, Circle manages keys. Do not sign transactions you do not understand.'
         ]
       }
@@ -379,14 +379,13 @@ const blogPosts: Record<string, BlogPost> = {
   },
   'circle-sdk-wallet-playbook': {
     slug: 'circle-sdk-wallet-playbook',
-    title:
-      'Circle SDK in Sendly: From Social Login to Managed Asset Flow',
+    title: 'Circle SDK in Sendly: Internal Wallet, Asset Flow, and NFT Cards',
     description:
-      'How Sendly uses Circle Developer-Controlled Wallets so social-only users can mint, claim, top up, and redeem NFT gift cards on Arc - without MetaMask.',
-    date: '2026-06-20',
+      'How Sendly uses Circle Developer Wallet: internal-wallet payments, funding and transfers, and minting NFT gift cards.',
+    date: '2026-04-14',
     category: 'Technology',
-    tags: ['Circle', 'Developer Wallets', 'Gateway', 'NFT', 'Arc Testnet', 'Privy'],
-    readTime: '12 min',
+    tags: ['Circle', 'Developer Wallets', 'NFT'],
+    readTime: '9 min',
     images: [
       {
         id: 'circle-create-wallet',
@@ -397,165 +396,90 @@ const blogPosts: Record<string, BlogPost> = {
       {
         id: 'circle-cover',
         componentId: 'internal-wallet-dashboard-embed',
-        alt: 'Internal Wallet dashboard in Sendly',
+        alt: 'Circle wallet flow in Sendly',
         caption: ''
       }
     ],
     sections: [
       {
-        id: 'why-internal-wallet',
-        title: 'Why an Internal Wallet exists',
+        id: 'overview',
+        title: 'What is the Internal Wallet?',
         paragraphs: [
-          'Sendly lets people send value to social identities, not just wallet addresses. That creates a product challenge: what happens when the recipient has a Twitch, X, Telegram, or Privy login, but no MetaMask wallet yet?',
-          <>
-            Sendly solves this with an Internal Wallet powered by{' '}
-            <a
-              href="https://developers.circle.com/wallets/dev-controlled"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-purple-700 underline hover:text-purple-900"
-            >
-              Circle Developer-Controlled Wallets
-            </a>
-            . The user signs in socially, the backend resolves or creates a Circle wallet, and Sendly can mint, claim, top up, or redeem on their behalf while keeping Circle credentials out of the browser.
-          </>,
-          'Circle Developer-Controlled Wallets are the infrastructure layer that lets Sendly serve users who arrive with a social identity first and a wallet later. This is a builder case study for that path-not a generic “Circle SDK” overview.'
+          'Sendly\'s Internal Wallet is Circle Developer Wallet (Circle SDK). If someone signs in with a social account and does not bring their own crypto wallet, they can still get an on-chain address and keep using the app.',
+          'This post describes what we ship: dashboard setup, balances and transfers, and NFT gift cards. The browser calls our API; the backend runs the wallet work.'
+        ],
+        bullets: [
+          'Find or create an internal Circle wallet for the logged-in user.',
+          'Read balances and fund the wallet (top-up or deposit-style flows).',
+          'Mint and claim NFT gift cards to a wallet address or a social handle.'
         ],
         imageId: 'circle-create-wallet'
       },
+      
       {
-        id: 'where-circle-sits',
-        title: 'Where Circle sits in Sendly',
+        id: 'dashboard-wallet',
+        title: 'Internal Wallet Flow',
         paragraphs: [
-          'Sendly is a USDC-first payment app for social identities. On Arc, the flow this article covers is NFT Gift Cards: ERC-721 cards with locked USDC/EURC value until the recipient claims. Internal Wallet, powered by Circle Developer-Controlled Wallets, signs mint, claim, top-up, and redeem when the user picks “Internal Wallet” instead of a browser wallet.',
-          'The system path is: React frontend → Supabase Edge Functions → Circle APIs → Arc contracts → Supabase Postgres. The browser owns UX and browser-wallet signing. Supabase owns privileged server operations. Circle owns wallet custody, Gateway/CCTP infrastructure, and programmatic signing. Arc settles contract calls.',
-          'The browser never talks to Circle for signing. The React app calls Edge Functions. Edge Functions hold Circle API credentials, encrypt the entity secret, execute wallet operations, and persist wallet and payment state in Postgres. Circle submits the transaction; Arc Network settles the contract call.'
-        ]
+          'Opening the wallet screen, the app looks for an existing Internal Wallet first: address, then linked social account, then Privy-related ids.',
+          'If nothing matches, we create a wallet through the backend. On some social claim paths the wallet is created automatically, then the claim tx runs.',
+          'Scenario 1: Social login, no web3 wallet yet. They create an Internal Wallet and can receive a payment to it. Some flows create the wallet right before claim.',
+          'Scenario 2: They already use a web3 wallet. They can still add an Internal Wallet and tie it to socials or to an external address, depending on how you wire identity.'
+        ],
+      
       },
       {
-        id: 'identity-before-wallet',
-        title: 'Identity before wallet',
+        id: 'asset-flow',
+        title: 'Asset flow: balances, top-up, and transfer',
         paragraphs: [
-          'An Internal Wallet is only useful if Sendly knows who owns it. Wallet resolution does not start at Circle-it starts at identity.',
-          'Resolution order: (1) connected browser wallet address, when the user already uses MetaMask, Rabby, or similar; (2) linked social identity-platform, social user ID, and username from OAuth; (3) Privy user ID as the final anchor when social rows are incomplete.',
-          'Once resolved, the backend stores Circle wallet ID, wallet set ID, wallet address, blockchain, account type, state, custody type, and social binding in `developer_wallets` (including `social_platform`, `social_user_id`, `social_username`, and `privy_user_id`).'
-        ]
-      },
-      {
-        id: 'two-wallet-modes',
-        title: 'Two wallet modes',
-        paragraphs: [
-          'Sendly is not “we have a wallet.” It is a fallback signing path for social-only users. Every feature that moves funds asks the same question: who signs this transaction?',
-          <>
-            <div className="overflow-x-auto my-6">
-              <table className="w-full text-left border border-gray-200 rounded-lg text-base">
-                <thead>
-                  <tr className="bg-gray-50 border-b border-gray-200">
-                    <th className="px-4 py-3 font-semibold text-gray-900">Mode</th>
-                    <th className="px-4 py-3 font-semibold text-gray-900">Who signs?</th>
-                    <th className="px-4 py-3 font-semibold text-gray-900">Good for</th>
-                  </tr>
-                </thead>
-                <tbody className="text-gray-700">
-                  <tr className="border-b border-gray-100">
-                    <td className="px-4 py-3 font-medium">External wallet</td>
-                    <td className="px-4 py-3">User signs in MetaMask, Rabby, etc.</td>
-                    <td className="px-4 py-3">Web3-native senders and recipients</td>
-                  </tr>
-                  <tr>
-                    <td className="px-4 py-3 font-medium">Internal Wallet</td>
-                    <td className="px-4 py-3">
-                      Backend signs through Circle Developer-Controlled Wallets
-                    </td>
-                    <td className="px-4 py-3">
-                      Social-only users, claim without MetaMask, backend-assisted mint and redeem
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </>,
-          'On the wallet screen, the app resolves an existing Internal Wallet before creating a new one. Social claim endpoints may call `create-for-social` immediately before `POST /wallets/send-transaction` so claim and wallet creation feel like one step to the user.'
-        ]
-      },
-      {
-        id: 'balances-top-up-gateway',
-        title: 'Balances, top-up, and Gateway',
-        paragraphs: [
-          'Asset movement here means three separate things: read ERC-20 balances on the Internal Wallet, fund the wallet (top-up from an external wallet), or move USDC across chains. Top-up and spend/redeem are different user stories-do not conflate them in support copy.',
-          'Balances and top-up from an external wallet are part of the shipped internal-wallet dashboard. The UI polls Circle by `transactionId` until a tx hash or terminal state appears; plan for pending states in product UX.',
-          'Circle Gateway / Unified Balance is implemented in frontend and backend but is still in testing-it should be presented as an integration under test, not the primary shipped user mode. The interactive flow uses approve → deposit → EIP-712 burn intent → attestation → mint; server-side flows use Unified Balance Kit on Edge Functions so the entity secret stays off the client.',
-          'Bridge Kit / CCTP is the better fit for direct point-to-point USDC bridging (for example Arc Testnet to Base Sepolia). Gateway is the better fit when the product wants a persistent unified balance and instant cross-chain spending from that balance.'
+          'When people say "pull asset" here, they usually mean one of three things: read balances, send funds into the Internal Wallet, or move value between supported networks or addresses.',
+          'The Internal Wallet screen reads ERC-20 balances and allows top-up from an external wallet. Gateway flows use approve and deposit, then burn intent, attestation, and mint.'
+        ],
+        bullets: [
+          'Gateway client/service modules hold the balance and transfer plumbing.',
+          'Internal Wallet UI includes top-up and test-token requests.',
+          'Transactions are not always synchronous: the UI polls by `transactionId` until it gets a hash or a final state.'
         ],
         imageId: 'circle-cover'
       },
       {
-        id: 'minting-nft-gift-cards',
-        title: 'Minting NFT gift cards',
+        id: 'nft-cards',
+        title: 'Create an NFT card from Circle Internal Wallet',
         paragraphs: [
-          'The sender creates a card with an optional message and USDC or EURC value; value stays locked in the GiftCard contract on Arc until the recipient claims.',
-          'Minting runs through `CreateGiftCard`: check balance and allowance, upload metadata (IPFS), then execute on Arc. Internal Wallet mode sends approve and mint via `DeveloperWalletService` → Circle API. External mode prompts the user\'s browser wallet.',
-          'Circle executes the contract call; the GiftCard contract mints the ERC-721 and locks value. The UI reads `tokenId` from the `Transfer` event. Social-directed cards (X, Twitch, Telegram, and others) stay in platform vaults until the matching username claims.'
+          'Gift cards are minted through `CreateGiftCard`. The app checks balance and allowance, prepares metadata, then calls the contract on whichever path you picked.',
+          'Internal Wallet mode routes the transaction through the backend. External wallet mode asks the user to confirm in their browser wallet.'
         ],
         bullets: [
-          'Sender path: Wallet Source toggle → Browser Wallet or Internal Wallet.',
-          'Recipient by username: card is escrowed until claim succeeds.',
-          'Recipient by address: NFT lands in that wallet after mint.'
+          'After mint, we read `tokenId` from the ERC-721 `Transfer` event.',
+          'X (Twitter), Twitch, Telegram, and similar recipients use separate create/claim paths.',
+          'After claim, the NFT is a normal ERC-721 in the recipient\'s context.'
         ]
       },
       {
-        id: 'claim-and-redeem',
-        title: 'Claim and redeem',
+        id: 'internal-wallet-stats',
+        title: 'Statistics',
         paragraphs: [
-          'Minting is half the lifecycle. When a recipient opens a social-directed card, Sendly validates the identity mapping (pending status, username match), then chooses who signs the claim transaction.',
-          'If the user supplies a browser wallet address, the client signs against the platform vault contract. If the recipient is social-only, Sendly resolves or creates an Internal Wallet (`POST /wallets/create-for-social` when needed), then submits the claim via `POST /wallets/send-transaction` with vault address, `claimCard` args, and the Circle wallet id.',
-          'After a successful claim, the recipient owns the ERC-721 card and can redeem its locked value. Redeem/spend in the app follows the same signing matrix: Internal Wallets use backend-signed contract calls; connected EOAs sign in the browser (for example Spend flow redemption to a selected service).',
-          'Always persist the tx hash before showing success-indexer and subgraph lag can otherwise flash the wrong state.'
-        ]
-      },
-      {
-        id: 'testnet-numbers',
-        title: 'Testnet numbers',
-        paragraphs: [
-          'Figures below count gift cards minted where the sender used Circle Developer-Controlled Wallets (Internal Wallet). Amounts are face value in token units (6 decimals on-chain). EURC is not USD; comparison to total testnet volume is indicative only.',
-          <>
-            Total testnet volume (~$310k) and Privy wallet methodology come from the same reporting window as{' '}
-            <Link to="/blog/privy-results" className="text-purple-700 underline hover:text-purple-900">
-              Privy testnet results
-            </Link>
-            . Re-run analytics before citing these in external decks.
-          </>
+          'Counts and amounts below are gift cards minted through Circle Developer Wallet (Internal Wallet). Balances use 6 decimals; raw is the integer in smallest units.',
+          'Our testnet writeup put total volume around $310k. The percentage is internal-wallet mint face value divided by that $310k number. Treat it as a rough comparison (EURC is not exactly USD).'
         ],
         bullets: [
-          'Users who minted via Internal Wallet: 220',
+          'Users who minted cards via Internal Wallet: 220',
           'Combined face value of those mints: 6,634',
-          'USDC portion: 4,499 · EURC portion: 2,134',
-          'Share of ~$310k total volume: ≈2.14%'
+          'USDC portion: 4,499',
+          'EURC portion: 2,134',
+          'Versus ~$310k total volume:≈ 2.14%.'
         ]
       },
       {
-        id: 'security-and-operations',
-        title: 'Security and operations',
+        id: 'security-and-ops',
+        title: 'Security and operational notes',
         paragraphs: [
-          <>
-            Circle API credentials, entity secrets, and service-role keys stay in Supabase Edge Function secrets. The browser only receives public config and transaction state. Circle&apos;s{' '}
-            <a
-              href="https://developers.circle.com/wallets/dev-controlled/entity-secret-management"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-purple-700 underline hover:text-purple-900"
-            >
-              entity secret
-            </a>{' '}
-            is developer-held; mutating wallet requests send fresh entity secret ciphertext, not the raw secret.
-          </>,
-          'For mutating wallet operations, the backend should use idempotency keys and treat Circle responses as asynchronous until a terminal transaction state or on-chain tx hash is available. Frontend and Edge both poll by `transactionId` (or use webhooks where configured) before showing final success.',
-          'Users should not sign transactions they do not understand. With developer-controlled wallets, Circle custody applies-be explicit in UX when Sendly, not MetaMask, is the signer. Flows in this article are validated on Arc Network; new chains need contract addresses, Circle blockchain config, and re-testing of Gateway and `send-transaction`.'
+          'Circle credentials and entity secrets belong on the server. The browser should keep calling your backend for anything that touches keys or signing.',
+          'Most of this was written for ARC-TESTNET. Other chains need testing and explicit config.'
         ],
         bullets: [
-          'Never embed production API keys or entity secrets in client bundles or scripts.',
-          'Log Edge request id together with Circle transaction ref for support tickets.',
-          'Before mainnet: threat-model social claim auto-create (username takeover → wallet linkage).'
+          'Do not ship production API secrets in scripts or client code.',
+          'Watch for slow finalization; the UI retries polling by `transactionId`.',
+          'Document per-chain switches before you enable Circle in a new environment.'
         ]
       }
     ],
@@ -763,7 +687,7 @@ export function BlogPostRoute() {
       if (img.componentId === 'zktls-infographic') {
         return (<button type="button" onClick={() => setActiveImage(img)} className="w-full text-left rounded-xl overflow-hidden bg-[#FAFAFA]" aria-label={`Open: ${img.caption}`}><ZkTLSInfographic compact />{img.caption && <div className="mt-3 text-sm text-gray-600">{img.caption}</div>}</button>);
       }
-      if (img.componentId === 'zktls-Architecture-infographic') {
+      if (img.componentId === 'zktls-architecture-infographic') {
         return (<button type="button" onClick={() => setActiveImage(img)} className="w-full text-left rounded-xl overflow-hidden bg-[#FAFAFA]" aria-label={`Open: ${img.caption}`}><ZkTLSArchitectureInfographic compact />{img.caption && <div className="mt-3 text-sm text-gray-600">{img.caption}</div>}</button>);
       }
       if (img.componentId === 'privy-oauth-infographic') {
@@ -1076,7 +1000,7 @@ export function BlogPostRoute() {
                   Scroll or pinch to zoom · Double-tap to zoom in
                 </p>
               </div>
-            ) : activeImage.componentId === 'zktls-Architecture-infographic' ? (
+            ) : activeImage.componentId === 'zktls-architecture-infographic' ? (
               <div className="bg-[#FAFAFA] overflow-hidden">
                 <TransformWrapper
                   initialScale={1}

--- a/src/pages/GitHubCallbackRoute.tsx
+++ b/src/pages/GitHubCallbackRoute.tsx
@@ -33,12 +33,8 @@ export function GitHubCallbackRoute() {
 
   useEffect(() => {
     if (hasExchangedRef.current) {
-      console.log('[POPUP] GitHub code exchange already completed, skipping...');
       return;
     }
-
-    console.log('[POPUP] GitHubCallbackRoute mounted');
-    console.log('[POPUP] Location:', location.pathname + location.search);
 
     const params = new URLSearchParams(location.search);
 
@@ -131,10 +127,13 @@ export function GitHubCallbackRoute() {
         }
 
         const accessToken = tokenData.accessToken;
-        localStorage.setItem('github_oauth', accessToken);
-        localStorage.setItem('github_oauth_token', accessToken);
-        if (tokenData.scope) {
-          localStorage.setItem('github_oauth_scope', tokenData.scope);
+        const hasOpener = window.opener && !window.opener.closed;
+        if (!hasOpener) {
+          localStorage.setItem('github_oauth', accessToken);
+          localStorage.setItem('github_oauth_token', accessToken);
+          if (tokenData.scope) {
+            localStorage.setItem('github_oauth_scope', tokenData.scope);
+          }
         }
 
         localStorage.removeItem('github_oauth_state');
@@ -144,7 +143,7 @@ export function GitHubCallbackRoute() {
         sessionStorage.removeItem('github_oauth_redirect');
         sessionStorage.removeItem('github_code_verifier');
 
-        if (window.opener && !window.opener.closed) {
+        if (hasOpener) {
           window.opener.postMessage(
             {
               type: 'github_oauth_token',

--- a/src/pages/GmailCallbackRoute.tsx
+++ b/src/pages/GmailCallbackRoute.tsx
@@ -28,12 +28,8 @@ export function GmailCallbackRoute() {
 
   useEffect(() => {
     if (hasExchangedRef.current) {
-      console.log('[POPUP] Gmail code exchange already completed, skipping...');
       return;
     }
-
-    console.log('[POPUP] GmailCallbackRoute mounted');
-    console.log('[POPUP] Location:', location.pathname + location.search);
 
     const params = new URLSearchParams(location.search);
 
@@ -140,15 +136,18 @@ export function GmailCallbackRoute() {
         }
 
         const accessToken = tokenData.accessToken;
-        localStorage.setItem('gmail_oauth', accessToken);
-        localStorage.setItem('gmail_oauth_token', accessToken);
-        if (tokenData.scope) {
-          localStorage.setItem('gmail_oauth_scope', tokenData.scope);
+        const hasOpener = window.opener && !window.opener.closed;
+        if (!hasOpener) {
+          localStorage.setItem('gmail_oauth', accessToken);
+          localStorage.setItem('gmail_oauth_token', accessToken);
+          if (tokenData.scope) {
+            localStorage.setItem('gmail_oauth_scope', tokenData.scope);
+          }
         }
 
         clearGmailOAuthStorage();
 
-        if (window.opener && !window.opener.closed) {
+        if (hasOpener) {
           window.opener.postMessage(
             {
               type: 'gmail_oauth_token',

--- a/src/pages/InstagramCallbackRoute.tsx
+++ b/src/pages/InstagramCallbackRoute.tsx
@@ -24,12 +24,8 @@ export function InstagramCallbackRoute() {
 
   useEffect(() => {
     if (hasExchangedRef.current) {
-      console.log('[POPUP] Instagram code exchange already completed, skipping...');
       return;
     }
-
-    console.log('[POPUP] InstagramCallbackRoute mounted');
-    console.log('[POPUP] Location:', location.pathname + location.search);
 
     const params = new URLSearchParams(location.search);
 
@@ -108,12 +104,15 @@ export function InstagramCallbackRoute() {
         }
 
         const accessToken = tokenData.accessToken;
-        localStorage.setItem('instagram_oauth', accessToken);
-        localStorage.setItem('instagram_oauth_token', accessToken);
+        const hasOpener = window.opener && !window.opener.closed;
+        if (!hasOpener) {
+          localStorage.setItem('instagram_oauth', accessToken);
+          localStorage.setItem('instagram_oauth_token', accessToken);
+        }
 
         clearInstagramOAuthStorage();
 
-        if (window.opener && !window.opener.closed) {
+        if (hasOpener) {
           window.opener.postMessage(
             {
               type: 'instagram_oauth_token',

--- a/src/pages/LinkedInCallbackRoute.tsx
+++ b/src/pages/LinkedInCallbackRoute.tsx
@@ -19,12 +19,8 @@ export function LinkedInCallbackRoute() {
 
   useEffect(() => {
     if (hasExchangedRef.current) {
-      console.log('[POPUP] LinkedIn code exchange already completed, skipping...');
       return;
     }
-
-    console.log('[POPUP] LinkedInCallbackRoute mounted');
-    console.log('[POPUP] Location:', location.pathname + location.search);
 
     const params = new URLSearchParams(location.search);
 
@@ -116,10 +112,13 @@ export function LinkedInCallbackRoute() {
         }
 
         const accessToken = tokenData.accessToken;
-        localStorage.setItem('linkedin_oauth', accessToken);
-        localStorage.setItem('linkedin_oauth_token', accessToken);
-        if (tokenData.scope) {
-          localStorage.setItem('linkedin_oauth_scope', tokenData.scope);
+        const hasOpener = window.opener && !window.opener.closed;
+        if (!hasOpener) {
+          localStorage.setItem('linkedin_oauth', accessToken);
+          localStorage.setItem('linkedin_oauth_token', accessToken);
+          if (tokenData.scope) {
+            localStorage.setItem('linkedin_oauth_scope', tokenData.scope);
+          }
         }
 
         localStorage.removeItem('linkedin_oauth_state');
@@ -129,7 +128,7 @@ export function LinkedInCallbackRoute() {
         sessionStorage.removeItem('linkedin_oauth_redirect');
         sessionStorage.removeItem('linkedin_code_verifier');
 
-        if (window.opener && !window.opener.closed) {
+        if (hasOpener) {
           window.opener.postMessage(
             {
               type: 'linkedin_oauth_token',

--- a/src/pages/TelegramAuthRoute.tsx
+++ b/src/pages/TelegramAuthRoute.tsx
@@ -73,10 +73,13 @@ export function TelegramAuthRoute() {
             return;
           }
 
-          localStorage.setItem('telegram_oauth_token', data.accessToken);
-          localStorage.setItem('telegram_oauth', data.accessToken);
+          const hasOpener = window.opener && !(window.opener as Window).closed;
+          if (!hasOpener) {
+            localStorage.setItem('telegram_oauth_token', data.accessToken);
+            localStorage.setItem('telegram_oauth', data.accessToken);
+          }
 
-          if (window.opener && !(window.opener as Window).closed) {
+          if (hasOpener) {
             (window.opener as Window).postMessage(
               { type: 'telegram_oauth_token', accessToken: data.accessToken, username: data.username },
               origin

--- a/src/pages/TwitchCallbackRoute.tsx
+++ b/src/pages/TwitchCallbackRoute.tsx
@@ -6,12 +6,6 @@ export function TwitchCallbackRoute() {
   const location = useLocation();
 
   useEffect(() => {
-    console.log('[POPUP] TwitchCallbackRoute mounted');
-    console.log('[POPUP] Location:', window.location.href);
-    console.log('[POPUP] Location hash:', location.hash);
-    console.log('[POPUP] Window opener exists:', !!window.opener);
-    console.log('[POPUP] Window opener closed:', window.opener?.closed);
-    
     const hash = location.hash.substring(1);
     const params = new URLSearchParams(hash);
     
@@ -20,11 +14,6 @@ export function TwitchCallbackRoute() {
     const state = params.get('state');
     const storedState = sessionStorage.getItem('twitch_oauth_state');
     const redirectUrl = sessionStorage.getItem('twitch_oauth_redirect') || '/dashboard';
-    
-    console.log('[POPUP] Access token found:', !!accessToken);
-    console.log('[POPUP] Error:', error);
-    console.log('[POPUP] State:', state);
-    console.log('[POPUP] Stored state:', storedState);
 
     if (error) {
       console.error('Twitch OAuth error:', error);
@@ -50,13 +39,11 @@ export function TwitchCallbackRoute() {
       return;
     }
 
-    // Save token to localStorage in popup window (will be copied to main window via postMessage)
-    // Use key 'twitch_oauth' as user suggested
-    console.log('[POPUP] Saving Twitch token to popup localStorage:', accessToken.substring(0, 20) + '...');
-    localStorage.setItem('twitch_oauth', accessToken);
-    // Also save with standard key for compatibility
-    localStorage.setItem('twitch_oauth_token', accessToken);
-    console.log('[POPUP] Token saved in popup. Verifying:', localStorage.getItem('twitch_oauth') ? 'Token found (key: twitch_oauth)' : 'Token NOT found!');
+    const hasOpener = window.opener && !window.opener.closed;
+    if (!hasOpener) {
+      localStorage.setItem('twitch_oauth', accessToken);
+      localStorage.setItem('twitch_oauth_token', accessToken);
+    }
     
     // Clean up temporary OAuth flow data
     sessionStorage.removeItem('twitch_oauth_state');
@@ -64,35 +51,23 @@ export function TwitchCallbackRoute() {
 
     // Notify parent window about successful authorization
     // IMPORTANT: This must happen BEFORE window.close() to ensure message is received
-    if (window.opener && !window.opener.closed) {
-      console.log('[POPUP] Sending token to parent window via postMessage...');
-      console.log('[POPUP] Parent window origin:', window.opener.location.origin);
-      console.log('[POPUP] Current window origin:', window.location.origin);
-      console.log('[POPUP] Token to send:', accessToken.substring(0, 20) + '...');
-      
+    if (hasOpener) {
       const messageData = {
         type: 'twitch_oauth_token',
         accessToken: accessToken
       };
-      
-      console.log('[POPUP] Message data:', messageData);
-      
+
       try {
         window.opener.postMessage(messageData, window.location.origin);
-        console.log('[POPUP] ✅ postMessage sent successfully to:', window.location.origin);
       } catch (error) {
-        console.error('[POPUP] ❌ Error sending postMessage:', error);
+        console.error('[POPUP] Error sending postMessage:', error);
       }
-      
-      console.log('[POPUP] Waiting 1 second before closing to ensure message is received...');
-      
+
       // Give parent window time to receive and save the token
       setTimeout(() => {
-        console.log('[POPUP] Closing popup window...');
         window.close();
       }, 1000);
     } else {
-      console.log('[POPUP] No window.opener or opener is closed, navigating instead...');
       navigate(redirectUrl);
     }
   }, [location, navigate]);

--- a/src/pages/TwitterCallbackRoute.tsx
+++ b/src/pages/TwitterCallbackRoute.tsx
@@ -16,15 +16,8 @@ export function TwitterCallbackRoute() {
 
   useEffect(() => {
     if (hasExchangedRef.current) {
-      console.log('[POPUP] Code exchange already completed, skipping...');
       return;
     }
-
-    console.log('[POPUP] TwitterCallbackRoute mounted');
-    console.log('[POPUP] Location:', location.pathname + location.search);
-    console.log('[POPUP] Location search:', location.search);
-    console.log('[POPUP] Window opener exists:', !!window.opener);
-    console.log('[POPUP] Window opener closed:', window.opener?.closed);
     
     const params = new URLSearchParams(location.search);
     
@@ -35,11 +28,6 @@ export function TwitterCallbackRoute() {
     const redirectUrl = sessionStorage.getItem('twitter_oauth_redirect') || '/dashboard';
     const codeVerifier = sessionStorage.getItem('twitter_code_verifier');
     
-    console.log('[POPUP] Authorization code found:', !!code);
-    console.log('[POPUP] Error:', error);
-    console.log('[POPUP] State:', state);
-    console.log('[POPUP] Stored state:', storedState);
-
     const closeOrRedirect = () => {
       if (window.opener && !window.opener.closed) {
         setTimeout(() => {
@@ -90,7 +78,6 @@ export function TwitterCallbackRoute() {
     }
 
     hasExchangedRef.current = true;
-    console.log('[POPUP] 🔒 Lock set to prevent duplicate code exchange');
 
     const exchangeCodeForToken = async () => {
       
@@ -100,20 +87,11 @@ export function TwitterCallbackRoute() {
         const apiUrl = getZkTlsApiUrl().replace(/\/$/, '');
         const fullUrl = `${apiUrl}/api/twitter/oauth/exchange`;
         
-        console.log('[POPUP] Exchange code for token:');
-        console.log('[POPUP] API URL:', apiUrl);
-        console.log('[POPUP] Full URL:', fullUrl);
-        console.log('[POPUP] Redirect URI:', redirectUri);
-        console.log('[POPUP] Has code verifier:', !!codeVerifier);
-        console.log('[POPUP] Code (first 10 chars):', code?.substring(0, 10) + '...');
-        
         const requestBody = {
           code: code,
           redirectUri: redirectUri,
           codeVerifier: codeVerifier || undefined,
         };
-        
-        console.log('[POPUP] Request body (without code):', { ...requestBody, code: '[REDACTED]' });
         
         const response = await fetch(fullUrl, {
           method: 'POST',
@@ -130,13 +108,6 @@ export function TwitterCallbackRoute() {
           });
           throw err;
         });
-        
-        console.log('[POPUP] Response received:', {
-          status: response.status,
-          statusText: response.statusText,
-          ok: response.ok,
-          headers: Object.fromEntries(response.headers.entries()),
-        });
 
         if (!response.ok) {
           const errorText = await response.text();
@@ -150,36 +121,27 @@ export function TwitterCallbackRoute() {
         }
 
         const accessToken = tokenData.accessToken;
-        console.log('[POPUP] ✅ Code exchange successful! Token received.');
-        console.log('[POPUP] Saving Twitter token to popup localStorage:', accessToken.substring(0, 20) + '...');
-        if (tokenData.tokenType) {
-          console.log('[POPUP] Twitter token type:', tokenData.tokenType);
+        const hasOpener = window.opener && !window.opener.closed;
+
+        if (!hasOpener) {
+          localStorage.setItem('twitter_oauth', accessToken);
+          localStorage.setItem('twitter_oauth_token', accessToken);
+          if (tokenData.tokenType) {
+            localStorage.setItem('twitter_oauth_token_type', tokenData.tokenType);
+          }
+          if (tokenData.scope) {
+            localStorage.setItem('twitter_oauth_scope', tokenData.scope);
+          }
+          if (tokenData.refreshToken) {
+            localStorage.setItem('twitter_refresh_token', tokenData.refreshToken);
+          }
         }
-        if (tokenData.scope) {
-          console.log('[POPUP] Twitter token scopes:', tokenData.scope);
-        }
-        localStorage.setItem('twitter_oauth', accessToken);
-        localStorage.setItem('twitter_oauth_token', accessToken);
-        if (tokenData.tokenType) {
-          localStorage.setItem('twitter_oauth_token_type', tokenData.tokenType);
-        }
-        if (tokenData.scope) {
-          localStorage.setItem('twitter_oauth_scope', tokenData.scope);
-        }
-        
-        if (tokenData.refreshToken) {
-          localStorage.setItem('twitter_refresh_token', tokenData.refreshToken);
-        }
-        
-        console.log('[POPUP] Token saved in popup. Verifying:', localStorage.getItem('twitter_oauth') ? 'Token found (key: twitter_oauth)' : 'Token NOT found!');
         
         sessionStorage.removeItem('twitter_oauth_state');
         sessionStorage.removeItem('twitter_oauth_redirect');
         sessionStorage.removeItem('twitter_code_challenge');
 
-        if (window.opener && !window.opener.closed) {
-          console.log('[POPUP] Sending token to parent window via postMessage...');
-          
+        if (hasOpener) {
           const messageData = {
             type: 'twitter_oauth_token',
             accessToken: accessToken
@@ -187,9 +149,8 @@ export function TwitterCallbackRoute() {
           
           try {
             window.opener.postMessage(messageData, window.location.origin);
-            console.log('[POPUP] ✅ postMessage sent successfully to:', window.location.origin);
           } catch (error) {
-            console.error('[POPUP] ❌ Error sending postMessage:', error);
+            console.error('[POPUP] Error sending postMessage:', error);
           }
         }
 

--- a/src/pages/TwitterOAuth1CallbackRoute.tsx
+++ b/src/pages/TwitterOAuth1CallbackRoute.tsx
@@ -57,10 +57,10 @@ const getPostMessageTargetOrigin = (): string => {
     try {
       return new URL(document.referrer).origin;
     } catch {
-      // ignore and fallback to wildcard
+      // ignore and fallback to same-origin
     }
   }
-  return '*';
+  return window.location.origin;
 };
 
 const getZkTlsApiUrl = (): string => {
@@ -116,13 +116,17 @@ export function TwitterOAuth1CallbackRoute() {
         const parsed = parseOAuth1AccessTokenResponse(raw);
 
         if (parsed?.oauthToken && parsed.oauthTokenSecret) {
-          localStorage.setItem('twitter_oauth1_token', parsed.oauthToken);
-          localStorage.setItem('twitter_oauth1_secret', parsed.oauthTokenSecret);
-          if (parsed.screenName) {
-            localStorage.setItem('twitter_oauth1_screen_name', parsed.screenName);
+          const hasOpener = window.opener && !window.opener.closed;
+
+          if (!hasOpener) {
+            localStorage.setItem('twitter_oauth1_token', parsed.oauthToken);
+            localStorage.setItem('twitter_oauth1_secret', parsed.oauthTokenSecret);
+            if (parsed.screenName) {
+              localStorage.setItem('twitter_oauth1_screen_name', parsed.screenName);
+            }
           }
 
-          if (window.opener && !window.opener.closed) {
+          if (hasOpener) {
             const targetOrigin = getPostMessageTargetOrigin();
             window.opener.postMessage(
               {

--- a/test/transactionHistoryAmounts.test.cjs
+++ b/test/transactionHistoryAmounts.test.cjs
@@ -48,3 +48,12 @@ test('no double conversion for already formatted blockchain amounts', async () =
   const human = formatTokenAmountString('12.34', { unit: 'human' });
   assert.equal(normalizeTokenAmount(human, { unit: 'human' }), 12.34);
 });
+
+test('gift_cards_graph sent amounts stay human (no micro division)', async () => {
+  const { normalizeTokenAmount, formatTokenAmountString } = await loadTokenAmount();
+  const storedAmount = '25';
+  const displayed = formatTokenAmountString(storedAmount, { unit: 'human' });
+  assert.equal(displayed, '25');
+  assert.equal(normalizeTokenAmount(displayed, { unit: 'human' }), 25);
+  assert.notEqual(normalizeTokenAmount(storedAmount, { unit: 'micro' }), 25);
+});

--- a/test/transactionHistoryAmounts.test.cjs
+++ b/test/transactionHistoryAmounts.test.cjs
@@ -1,0 +1,50 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+async function loadTokenAmount() {
+  return import('../src/lib/tokenAmount.ts');
+}
+
+test('micro-unit string converts to human amount', async () => {
+  const { normalizeTokenAmount, formatTokenAmountString } = await loadTokenAmount();
+  assert.equal(normalizeTokenAmount('1000000', { unit: 'micro' }), 1);
+  assert.equal(formatTokenAmountString('2500000', { unit: 'micro' }), '2.5');
+});
+
+test('human decimal string is not divided again', async () => {
+  const { normalizeTokenAmount, formatTokenAmountString } = await loadTokenAmount();
+  assert.equal(normalizeTokenAmount('10.5', { unit: 'human' }), 10.5);
+  assert.equal(normalizeTokenAmount('10.5', { unit: 'micro' }), 10.5);
+  assert.equal(formatTokenAmountString('3.25', { unit: 'human' }), '3.25');
+});
+
+test('human integer string passes through', async () => {
+  const { normalizeTokenAmount } = await loadTokenAmount();
+  assert.equal(normalizeTokenAmount('42', { unit: 'human' }), 42);
+});
+
+test('zero and empty values', async () => {
+  const { normalizeTokenAmount, formatTokenAmountString } = await loadTokenAmount();
+  assert.equal(normalizeTokenAmount('0', { unit: 'micro' }), 0);
+  assert.equal(normalizeTokenAmount('', { unit: 'human' }), 0);
+  assert.equal(formatTokenAmountString('0', { unit: 'micro' }), '0');
+});
+
+test('bigint micro-units', async () => {
+  const { normalizeTokenAmount } = await loadTokenAmount();
+  assert.equal(normalizeTokenAmount(5_000_000n, { unit: 'micro' }), 5);
+});
+
+test('formatDisplayAmount rounds to decimals', async () => {
+  const { formatDisplayAmount } = await loadTokenAmount();
+  assert.equal(formatDisplayAmount(1.23456, 2), '1.23');
+  assert.equal(formatDisplayAmount(1.23556, 2), '1.24');
+  assert.equal(formatDisplayAmount('414.97', 2), '414.97');
+  assert.equal(formatDisplayAmount(Number.NaN, 2), '0.00');
+});
+
+test('no double conversion for already formatted blockchain amounts', async () => {
+  const { normalizeTokenAmount, formatTokenAmountString } = await loadTokenAmount();
+  const human = formatTokenAmountString('12.34', { unit: 'human' });
+  assert.equal(normalizeTokenAmount(human, { unit: 'human' }), 12.34);
+});

--- a/utils/mpp/mppGateway.ts
+++ b/utils/mpp/mppGateway.ts
@@ -1,4 +1,4 @@
-import { getApiUrl, supabase } from '../supabase/client';
+import { getApiUrl, supabase } from '../../src/lib/supabase/client';
 
 type PaidCallResult<T> =
   | { ok: true; data: T; receipt: string | null }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -105,9 +105,9 @@ export default defineConfig(({ mode }) => {
 
   const zktlsTarget = env.VITE_ZKTLS_PROXY_TARGET || 'http://localhost:3002';
   const server: Record<string, unknown> = {
-    port: 3000,
+    port: 3002,
     host: true,
-    open: useHttps ? 'https://localhost:3000' : true,
+    open: useHttps ? 'https://localhost:3002' : true,
     strictPort: true,
     proxy: {
       '/api': {


### PR DESCRIPTION
Refactor CreateGiftCard, giftCardFlows, developerWalletFlow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large gift-card refactor touches mint/claim paths and Circle polling; OAuth and removal of client API keys need correct backend env and parent-window handlers or voice/IPFS flows will break.
> 
> **Overview**
> **CreateGiftCard** is slimmed down by moving wallet lookup, validation, Circle/browser mint paths, persistence, and error handling into `src/components/gift-card/*` (e.g. `giftCardFlow`, `developerWalletFlow`, `useDeveloperWalletLookup`). UI wiring stays in the component; behavior is intended to match the previous inline implementation.
> 
> **Third-party API keys** are removed from the browser: AIML/OpenAI parsing, ElevenLabs transcription, and Pinata uploads now require env-configured backend URLs (`VITE_AI_PARSE_FUNCTION_URL`, `VITE_AUDIO_TRANSCRIBE_FUNCTION_URL`, `VITE_PINATA_UPLOAD_FUNCTION_URL`) and fail fast if unset.
> 
> **Transaction history** adds `tokenAmount` helpers and an `AnalyticsAmount` display so zkSend and gift-card rows are normalized as human amounts (avoiding micro-unit double conversion). Tests cover the conversion rules.
> 
> **OAuth popup callbacks** (GitHub, Gmail, Instagram, LinkedIn, Telegram, Twitch, Twitter, OAuth1) only write tokens to `localStorage` when there is no opener; popup flows rely on `postMessage` instead. Twitter OAuth1 `postMessage` target origin is tightened from `*` to same-origin/referrer.
> 
> Smaller updates: public gift-card demo copy stresses non-production; architecture map blurbs; blog Circle SDK post shortened; dev server default port **3002**; minor VoicePaymentAgent guard/logging cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f29314c0720a5cba858bb050543c49cc6b5789ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->