### PR TITLE
Feat/ignyte

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,10 @@ tmp/
 # Duplicate assets (use public/ only)
 /download.png
 
-*.md
+.agents/
+.cursor - copy/
+.opencode/
+docs-old/
 !docs/Architecture.md
 !docs/Agent-Treasury.md
 /artifacts/

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -14,6 +14,7 @@ For autonomous agent settlement (GitHub repo treasury, Twitch raid-to-pay), see 
 | Circle Developer-Controlled Wallets | Implemented | `DeveloperWalletService`, backend Circle API calls |
 | Bridge Kit / CCTP | Implemented | `@circle-fin/bridge-kit` + viem adapter |
 | Payments via zkTLS | Implemented | `zkSEND` contract + social identity hash + zkTLS verification |
+| Sendly Remit (`/remit`) | Implemented | AED display UX over the same zkSEND send path; see [Sendly Remit](#sendly-remit) |
 | Agent Treasury (GitHub / Twitch) | Implemented | `creator-paywall` Edge Function, sponsor pool → `ZkSend`, receipts API, Lepton UI - see [Agent Treasury](./Agent-Treasury.md) |
 
 ## Planned Next
@@ -150,6 +151,19 @@ sequenceDiagram
     ZkTLS-->>ZkSend: Submit zk-proof on-chain
     ZkSend-->>Recipient: Transfer stablecoins to recipient wallet
 ```
+
+## Sendly Remit
+
+`/remit` is a remittance-shaped UI over zkTLS Direct Payments. Settlement is still USDC on Arc via `zkSEND`; there is no separate remittance contract or backend rail.
+
+What differs from `/payments`:
+
+- Amount is entered in AED and converted to USDC with a fixed demo FX quote (`remitQuote.ts`) before `submitSocialZkSendPayment`.
+- Recipient platform is locked to Twitter/X.
+- Destination country is display-only.
+- Funding source can be Internal Wallet, External Wallet, or a mock UAE bank card. The card option is visual only; pay-in still settles from a real wallet (Circle or browser).
+
+Claim stays on the existing receive flow (`/payments?tab=receive`).
 
 ## Circle Gateway and Unified Balance
 

--- a/docs/OpenSpec-Traceability.md
+++ b/docs/OpenSpec-Traceability.md
@@ -1,0 +1,95 @@
+# OpenSpec Traceability
+
+Maps **OpenSpec main-spec requirements** (`openspec/specs/`) to implementation paths across Sendly repositories. Use this index when reviewing shipped behavior, onboarding, or updating docs after `openspec archive`.
+
+**Audience:** engineers, hackathon reviewers, spec authors.
+
+**Narrative architecture** (workflows, diagrams, product context) lives in [Architecture](./Architecture.md) and [Agent Treasury](./Agent-Treasury.md). This file is the requirement → code index only.
+
+## Phase-1 scope
+
+Tables cover capabilities promoted to `openspec/specs/` at the time of this document:
+
+| Capability | Spec file | Requirements |
+|---|---|---|
+| `agent-treasury-doc` | `openspec/specs/agent-treasury-doc/spec.md` | 7 |
+| `architecture-overview` | `openspec/specs/architecture-overview/spec.md` | 5 |
+
+**Out of scope (phase 1):**
+
+- Creator paywall (`social-x402-paywall-zksend`)
+- Citation demo (`/lepton/citation`)
+- Capabilities that exist only in `openspec/changes/` or archive and are not yet main specs
+- Gateway, gift cards, modular wallet, and other product areas without a main spec
+
+Extend this doc when new capabilities are archived to `openspec/specs/`.
+
+## How to read tables
+
+| Column | Meaning |
+|---|---|
+| **Requirement** | Header from the capability's `spec.md` (`### Requirement: …`) |
+| **Repo** | `Sendly-App`, `sendly-supabase`, `sendly-contracts`, or `docs` |
+| **Path(s)** | Relative to that repo's root; comma-separated when multiple |
+| **Notes** | Endpoints, migrations, UI routes, or doc sections |
+
+## Maintenance
+
+Update traceability rows when:
+
+1. **`openspec archive`** creates or modifies a capability in `openspec/specs/`
+2. Implementation paths move materially (e.g. function split, route rename)
+3. A requirement is added, renamed, or removed in a main spec
+
+Add a new `## Capability: <name>` section per promoted capability. Keep paths at module or route level — not every function.
+
+**Future improvement:** script to diff `openspec/specs/*/spec.md` requirement headers against table rows.
+
+## Related docs
+
+- [Architecture](./Architecture.md) — product-wide architecture
+- [Agent Treasury](./Agent-Treasury.md) — GitHub / Twitch agent workflows
+- OpenSpec main specs — `openspec/specs/` (local; gitignored in Sendly-App)
+
+---
+
+## Capability: `agent-treasury-doc`
+
+Spec: `openspec/specs/agent-treasury-doc/spec.md`
+
+| Requirement | Repo | Path(s) | Notes |
+|---|---|---|---|
+| Agent Treasury document exists at docs path | docs | `docs/Agent-Treasury.md` | Purpose, scope, exclusions |
+| Document encodes architectural decisions | docs | `docs/Agent-Treasury.md` | § Architectural Decisions table |
+| GitHub Agent Workflow documented | sendly-supabase | `functions/arc/creator-paywall/index.ts`, `prPayout.ts` | `POST /webhooks/github`, `GET /pr-payouts`; webhook ~L1240, receipts ~L1319 |
+| GitHub Agent Workflow documented | sendly-supabase | `migrations/050_github_pr_payout_agent.sql` | `pr_payout_policies`, `github_pr_payouts` |
+| GitHub Agent Workflow documented | sendly-contracts | `zktls_payments/ZkSend.sol` | `createPayment` to `github:{login}` identity hash |
+| GitHub Agent Workflow documented | Sendly-App | `src/lib/paywall/prPayoutAPI.ts`, `src/pages/LeptonReceiptsRoute.tsx`, `src/pages/LeptonRepoSettingsRoute.tsx`, `src/pages/LeptonPrBountyRoute.tsx`, `src/components/lepton/LeptonReceiptsPage.tsx`, `src/components/lepton/LeptonRepoSettingsPage.tsx` | Human UI; routes in `src/App.tsx` |
+| Twitch Agent Workflow documented | sendly-supabase | `functions/arc/creator-paywall/index.ts`, `twitchEventSubClient.ts`, `twitchPayoutCore.ts`, `twitchWebhook.ts` | `POST /webhooks/twitch`, `GET /twitch-payouts`; raid handler ~L1530 |
+| Twitch Agent Workflow documented | sendly-supabase | `migrations/052_twitch_raid_payouts.sql` | `twitch_campaigns`, `twitch_payout_policies`, receipts |
+| Twitch Agent Workflow documented | sendly-contracts | `zktls_payments/ZkSend.sol` | Payout to `twitch:uid:{id}` |
+| Twitch Agent Workflow documented | Sendly-App | `src/lib/paywall/twitchPayoutAPI.ts`, `src/pages/LeptonTwitchCampaignRoute.tsx`, `src/pages/LeptonTwitchReceiptsRoute.tsx`, `src/components/lepton/LeptonTwitchCampaignPage.tsx`, `src/components/lepton/LeptonTwitchReceiptsPage.tsx` | uid-aware claim; routes in `src/App.tsx` |
+| Twitch Agent Workflow documented | zktls-service | Twitch uid provider | Identity `twitch:uid:{user_id}` for claim proof |
+| Agent discovery section documents public endpoints | sendly-supabase | `functions/arc/creator-paywall/llm.txt`, `openapi.json` | SoT for agent machine docs |
+| Agent discovery section documents public endpoints | Sendly-App | `scripts/sync-agent-docs.mjs`, `public/llm.txt`, `public/llms.txt`, `public/openapi.json` | Build-time sync; `GET /lepton-hackathon` served from Edge Function |
+| Agent discovery section documents public endpoints | Sendly-App | `src/lib/paywall/leptonCatalogAPI.ts`, `src/components/lepton/LeptonCatalogView.tsx` | Frontend catalog consumer |
+| Source of truth matrix | docs | `docs/Agent-Treasury.md` | § Source of Truth table |
+| Source of truth matrix | sendly-supabase | `functions/arc/creator-paywall/` | Backend SoT |
+| Source of truth matrix | Sendly-App | `src/lib/paywall/prPayoutAPI.ts`, `src/lib/paywall/twitchPayoutAPI.ts`, `src/components/lepton/` | Frontend SoT for Lepton UI |
+| Cross-link to Architecture | docs | `docs/Agent-Treasury.md` | Link to `./Architecture.md` in intro |
+
+---
+
+## Capability: `architecture-overview`
+
+Spec: `openspec/specs/architecture-overview/spec.md`
+
+| Requirement | Repo | Path(s) | Notes |
+|---|---|---|---|
+| Implemented Now lists Agent Treasury | docs | `docs/Architecture.md` | § Implemented Now table, Agent Treasury row (~L17) |
+| Agent Wallet status reflects partial implementation | docs | `docs/Architecture.md` | § Planned Next, Agent Wallet row (~L24) |
+| Identity section acknowledges zk OAuth parallel stack | docs | `docs/Architecture.md` | § Identity and Wallet Resolution (~L58–68) |
+| Identity section acknowledges zk OAuth parallel stack | Sendly-App | `src/components/DeveloperWallet.tsx`, `src/lib/zk-oauth/` | `checkWalletWithFallback()`, zk OAuth wallet lookup |
+| Architecture links to Agent Treasury doc | docs | `docs/Architecture.md` | Intro link to `./Agent-Treasury.md` (~L7) |
+| Architecture links to OpenSpec traceability doc | docs | `docs/Architecture.md` | Intro link to `./OpenSpec-Traceability.md` |
+| Minimal patch scope preserved | docs | `docs/Architecture.md`, `docs/OpenSpec-Traceability.md` | Workflows in Agent-Treasury; traceability tables here only — not in Architecture.md |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import { BlogRoute } from '@/pages/BlogRoute';
 import { BlogPostRoute } from '@/pages/BlogPostRoute';
 import { ReclaimCallbackRoute } from '@/pages/ReclaimCallbackRoute';
 import { ZkSendRoute } from '@/pages/ZkSendRoute';
+import { RemitRoute } from '@/pages/RemitRoute';
 import { CreatorWriteRoute } from '@/pages/CreatorWriteRoute';
 import { CreatorHomeRoute } from '@/pages/CreatorHomeRoute';
 import { CreatorProfileRoute } from '@/pages/CreatorProfileRoute';
@@ -64,6 +65,7 @@ function SharedAppRoutes({ zkMode }: { zkMode: boolean }) {
       <Route path="/auth/telegram" element={<TelegramAuthRoute />} />
       <Route path="/reclaim/callback" element={<ReclaimCallbackRoute />} />
       <Route path="/payments" element={zkMode ? <ZkSendRoute /> : <ZkHostRedirect />} />
+      <Route path="/remit" element={zkMode ? <RemitRoute /> : <ZkHostRedirect />} />
       <Route path="/creator/write" element={zkMode ? <CreatorWriteRoute /> : <ZkHostRedirect />} />
       <Route path="/creator/:platform/:handle" element={zkMode ? <CreatorProfileRoute /> : <ZkHostRedirect />} />
       <Route path="/creator" element={zkMode ? <CreatorHomeRoute /> : <ZkHostRedirect />} />

--- a/src/components/RecipientAvatar.tsx
+++ b/src/components/RecipientAvatar.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useState, useEffect, useRef } from 'react';
-import { fetchTwitterUserPreview } from '@/lib/twitter/userLookup';
+import { fetchTwitterUserPreview, upgradeTwitterAvatarUrl } from '@/lib/twitter/userLookup';
 import { fetchTwitchUserPreview } from '@/lib/twitch/userLookup';
 
 type SocialPlatform = 'twitter' | 'twitch' | 'telegram' | 'discord' | 'tiktok' | 'instagram' | '';
@@ -68,21 +68,26 @@ export function RecipientAvatar({ platform = '', counterpart, displayName, alt }
   const key = `${platform}:${counterpart}`;
   const [avatarUrl, setAvatarUrl] = useState<string | null>(() => avatarCache.get(key) ?? null);
   const fetchedRef = useRef(false);
-  const retryRef = useRef(false);
+  const retryPhaseRef = useRef<'none' | 'upgraded' | 'refreshed'>('none');
 
   useEffect(() => {
-    if (!canFetchAvatar(platform, counterpart) || fetchedRef.current) return;
+    retryPhaseRef.current = 'none';
+    fetchedRef.current = false;
+    if (!canFetchAvatar(platform, counterpart)) {
+      setAvatarUrl(null);
+      return;
+    }
     if (avatarCache.has(key)) {
       setAvatarUrl(avatarCache.get(key)!);
       return;
     }
     fetchedRef.current = true;
 
-    const fetchAvatar = async (skipCache = false) => {
+    const fetchAvatar = async () => {
       try {
         let url: string | null = null;
         if (platform === 'twitter') {
-          const res = await fetchTwitterUserPreview(counterpart, skipCache ? { skipCache: true } : undefined);
+          const res = await fetchTwitterUserPreview(counterpart);
           if (res.success && res.data.profile_image_url) url = res.data.profile_image_url;
         } else if (platform === 'twitch') {
           const res = await fetchTwitchUserPreview(counterpart);
@@ -102,28 +107,34 @@ export function RecipientAvatar({ platform = '', counterpart, displayName, alt }
   }, [platform, counterpart, key]);
 
   const handleImageError = () => {
-    if (retryRef.current) {
-      setAvatarUrl(null);
+    if (!avatarUrl) return;
+
+    if (retryPhaseRef.current === 'none') {
+      const upgraded = platform === 'twitter' ? upgradeTwitterAvatarUrl(avatarUrl) : null;
+      if (upgraded) {
+        retryPhaseRef.current = 'upgraded';
+        avatarCache.set(key, upgraded);
+        setAvatarUrl(upgraded);
+        return;
+      }
+    }
+
+    if (platform === 'twitter' && retryPhaseRef.current !== 'refreshed') {
+      retryPhaseRef.current = 'refreshed';
+      fetchTwitterUserPreview(counterpart, { refresh: true }).then((res) => {
+        if (res.success && res.data.profile_image_url) {
+          avatarCache.set(key, res.data.profile_image_url);
+          setAvatarUrl(res.data.profile_image_url);
+          return;
+        }
+        avatarCache.delete(key);
+        setAvatarUrl(null);
+      });
       return;
     }
-    retryRef.current = true;
+
     avatarCache.delete(key);
     setAvatarUrl(null);
-    if (platform === 'twitter') {
-      fetchTwitterUserPreview(counterpart, { skipCache: true }).then((res) => {
-        if (res.success && res.data.profile_image_url) {
-          avatarCache.set(key, res.data.profile_image_url!);
-          setAvatarUrl(res.data.profile_image_url);
-        }
-      });
-    } else if (platform === 'twitch') {
-      fetchTwitchUserPreview(counterpart).then((res) => {
-        if (res.success && res.data.profile_image_url) {
-          avatarCache.set(key, res.data.profile_image_url!);
-          setAvatarUrl(res.data.profile_image_url);
-        }
-      });
-    }
   };
 
   const letter = displayName?.charAt(0)?.toUpperCase() || '?';
@@ -136,6 +147,7 @@ export function RecipientAvatar({ platform = '', counterpart, displayName, alt }
           src={avatarUrl}
           alt={alt ?? `Profile of ${displayName}`}
           className="size-10 rounded-full object-cover bg-slate-200 dark:bg-slate-600"
+          referrerPolicy="no-referrer"
           onError={handleImageError}
         />
       ) : (

--- a/src/components/zk-accounts/ZkAppShell.tsx
+++ b/src/components/zk-accounts/ZkAppShell.tsx
@@ -76,7 +76,7 @@ export function ZkAppShell({
             </div>
           </nav>
 
-          <Card className="bg-white shadow-circle-card rounded-2xl backdrop-blur-sm">{children}</Card>
+          <Card className="w-full min-w-0 bg-white shadow-circle-card rounded-2xl backdrop-blur-sm">{children}</Card>
         </div>
 
         {!isCompact && expanded ? (

--- a/src/components/zksend/PendingPayments.tsx
+++ b/src/components/zksend/PendingPayments.tsx
@@ -84,6 +84,8 @@ type Props = {
   hasDeveloperWallet?: boolean;
   /** Override card title (default: Receive). */
   title?: string;
+  /** Payment to visually identify when opened from a remit claim link. */
+  highlightPaymentId?: string | null;
 };
 
 function shortenAddress(addr: string): string {
@@ -195,6 +197,7 @@ export function PendingPayments({
   developerWallet = null,
   hasDeveloperWallet = false,
   title = 'Receive',
+  highlightPaymentId = null,
 }: Props) {
   const connectedChainId = useChainId();
   const activeChainId = connectedChainId || ARC_CHAIN_ID;
@@ -1581,7 +1584,9 @@ export function PendingPayments({
               {rows.map((p) => (
                 <div
                   key={p.paymentId}
-                  className="flex flex-col gap-2 rounded-lg border p-3 md:flex-row md:items-center md:justify-between"
+                  className={`flex flex-col gap-2 rounded-lg border p-3 md:flex-row md:items-center md:justify-between ${
+                    highlightPaymentId === p.paymentId ? 'border-emerald-400 bg-emerald-50/70 dark:bg-emerald-950/20' : ''
+                  }`}
                 >
                   <div className="space-y-1">
                     <div className="text-sm font-medium">Payment</div>

--- a/src/components/zksend/PlatformUsernameInput.tsx
+++ b/src/components/zksend/PlatformUsernameInput.tsx
@@ -13,7 +13,7 @@ function TelegramIcon({ className, ...props }: React.SVGAttributes<SVGSVGElement
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { fetchTwitterUserPreview, normalizeTwitterHandle, type TwitterUserPreview } from '@/lib/twitter';
+import { fetchTwitterUserPreview, normalizeTwitterHandle, upgradeTwitterAvatarUrl, TWITTER_CACHE_SOFT_TTL_MS, type TwitterUserPreview } from '@/lib/twitter';
 import {
   fetchTwitchUserPreview,
   normalizeTwitchLogin,
@@ -47,7 +47,18 @@ function recipientPlaceholder(platform: SendRecipientType): string {
 }
 
 /** Module-level cache for successful Twitter previews (key = normalized username). Survives tab switch. */
-const twitterPreviewCache = new Map<string, TwitterUserPreview>();
+const twitterPreviewCache = new Map<string, { data: TwitterUserPreview; fetchedAt: number }>();
+
+function getFreshTwitterMemoryCache(username: string): TwitterUserPreview | null {
+  const entry = twitterPreviewCache.get(username);
+  if (!entry) return null;
+  if (Date.now() - entry.fetchedAt >= TWITTER_CACHE_SOFT_TTL_MS) return null;
+  return entry.data;
+}
+
+function setTwitterMemoryCache(username: string, data: TwitterUserPreview) {
+  twitterPreviewCache.set(username, { data, fetchedAt: Date.now() });
+}
 
 /** Module-level cache for successful Twitch previews (key = normalized login). Survives tab switch. */
 const twitchPreviewCache = new Map<string, TwitchUserPreview>();
@@ -130,8 +141,8 @@ export function PlatformUsernameInput({
   const telegramDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const telegramLastRequestRef = useRef<string>('');
   const telegramInFlightRequestRef = useRef<string>('');
-  /** After 404 Twitter avatar, do one refetch with skipCache. Reset when username changes. */
-  const twitterAvatarRetryRef = useRef(false);
+  /** Avatar recovery: none → try CDN size → quiet API refresh → drop image. Reset when username changes. */
+  const twitterAvatarRetryPhaseRef = useRef<'none' | 'upgraded' | 'refreshed'>('none');
   const lastTwitterUsernameRef = useRef<string>('');
 
   const currentPlatformOpt = PLATFORM_OPTIONS.find((o) => o.value === platform) ?? PLATFORM_OPTIONS[0];
@@ -146,7 +157,7 @@ export function PlatformUsernameInput({
 
   if (lastTwitterUsernameRef.current !== normalizedUsername) {
     lastTwitterUsernameRef.current = normalizedUsername;
-    twitterAvatarRetryRef.current = false;
+    twitterAvatarRetryPhaseRef.current = 'none';
   }
 
   useEffect(() => {
@@ -162,17 +173,27 @@ export function PlatformUsernameInput({
       return;
     }
 
-    const cached = twitterPreviewCache.get(normalizedUsername);
-    if (cached) {
+    const memoryFresh = getFreshTwitterMemoryCache(normalizedUsername);
+    if (memoryFresh) {
       setPreviewStatus('success');
-      setPreviewData(cached);
+      setPreviewData(memoryFresh);
       setPreviewError(null);
       return;
     }
 
+    // Soft-stale memory: show immediately, still revalidate below.
+    const memoryStale = twitterPreviewCache.get(normalizedUsername)?.data ?? null;
+    if (memoryStale) {
+      setPreviewStatus('success');
+      setPreviewData(memoryStale);
+      setPreviewError(null);
+    }
+
     if (debounceRef.current) clearTimeout(debounceRef.current);
-    setPreviewStatus('loading');
-    setPreviewError(null);
+    if (!memoryStale) {
+      setPreviewStatus('loading');
+      setPreviewError(null);
+    }
 
     debounceRef.current = setTimeout(() => {
       debounceRef.current = null;
@@ -185,11 +206,11 @@ export function PlatformUsernameInput({
         .then((result) => {
           if (lastRequestRef.current !== requested) return;
           if (result.success) {
-            twitterPreviewCache.set(requested, result.data);
+            setTwitterMemoryCache(requested, result.data);
             setPreviewStatus('success');
             setPreviewData(result.data);
             setPreviewError(null);
-          } else {
+          } else if (!memoryStale) {
             setPreviewStatus('error');
             setPreviewData(null);
             setPreviewError(result.error);
@@ -208,26 +229,54 @@ export function PlatformUsernameInput({
     };
   }, [showTwitterPreview, normalizedUsername]);
 
+  /**
+   * Image CDN failed (often after avatar change): try CDN size upgrade, then quiet API refresh.
+   * Never clear the successful preview / show "Twitter API error" - keep name + handle.
+   */
   const handleTwitterAvatarError = () => {
-    if (twitterAvatarRetryRef.current || !normalizedUsername) return;
-    twitterAvatarRetryRef.current = true;
-    twitterPreviewCache.delete(normalizedUsername);
-    setPreviewStatus('loading');
-    setPreviewError(null);
-    fetchTwitterUserPreview(normalizedUsername, { skipCache: true })
-      .then((result) => {
-        if (result.success) {
-          twitterPreviewCache.set(normalizedUsername, result.data);
+    const phase = twitterAvatarRetryPhaseRef.current;
+    const handle = normalizedUsername;
+    if (!handle) return;
+
+    if (phase === 'none') {
+      const currentUrl = previewData?.profile_image_url;
+      const upgraded = currentUrl ? upgradeTwitterAvatarUrl(currentUrl) : null;
+      if (upgraded && previewData) {
+        twitterAvatarRetryPhaseRef.current = 'upgraded';
+        const next = { ...previewData, profile_image_url: upgraded };
+        setTwitterMemoryCache(handle, next);
+        setPreviewData(next);
+        return;
+      }
+    }
+
+    if (phase !== 'refreshed') {
+      twitterAvatarRetryPhaseRef.current = 'refreshed';
+      fetchTwitterUserPreview(handle, { refresh: true }).then((result) => {
+        if (lastTwitterUsernameRef.current !== handle) return;
+        if (result.success && result.data.profile_image_url) {
+          setTwitterMemoryCache(handle, result.data);
           setPreviewStatus('success');
           setPreviewData(result.data);
           setPreviewError(null);
-        } else {
-          setPreviewStatus('error');
-          setPreviewData(null);
-          setPreviewError(result.error);
+          return;
         }
-      })
-      .finally(() => {});
+        setPreviewData((current) => {
+          if (!current) return current;
+          const fallback = { ...current, profile_image_url: null };
+          setTwitterMemoryCache(normalizeTwitterHandle(current.username), fallback);
+          return fallback;
+        });
+      });
+      return;
+    }
+
+    setPreviewData((current) => {
+      if (!current) return current;
+      const fallback = { ...current, profile_image_url: null };
+      setTwitterMemoryCache(normalizeTwitterHandle(current.username), fallback);
+      return fallback;
+    });
   };
 
   useEffect(() => {
@@ -568,6 +617,7 @@ export function PlatformUsernameInput({
                   className="h-8 w-8 shrink-0 rounded-full object-cover"
                   width={32}
                   height={32}
+                  referrerPolicy="no-referrer"
                   onError={handleTwitterAvatarError}
                 />
               ) : (

--- a/src/components/zksend/PlatformUsernameInput.tsx
+++ b/src/components/zksend/PlatformUsernameInput.tsx
@@ -76,7 +76,7 @@ const PLATFORM_OPTIONS: {
   icon: React.ComponentType<{ className?: string }>;
   disabled?: boolean;
 }[] = [
-  { value: 'twitter', label: 'Twitter / X', hint: 'Send to handle', icon: Twitter },
+  { value: 'twitter', label: 'X', hint: 'Send to handle', icon: Twitter },
   { value: 'twitch', label: 'Twitch', hint: 'Send to username', icon: Twitch },
   { value: 'github', label: 'GitHub', hint: 'Send to username', icon: Github },
   { value: 'telegram', label: 'Telegram', hint: 'Send to username', icon: TelegramIcon },
@@ -96,6 +96,8 @@ type Props = {
   ariaLabel?: string;
   /** Read-only display (e.g. blog embed): no editing, same look, no disabled styling. */
   readOnly?: boolean;
+  /** Hide platform picker and keep the current platform fixed (e.g. Remit → Twitter only). */
+  lockPlatform?: boolean;
   /** In readOnly mode, show this as the suggestion line (e.g. "Arc @arc") without fetching. */
   previewSuggestionLabel?: string;
   /** In readOnly mode, show this avatar in the suggestion line. */
@@ -113,6 +115,7 @@ export function PlatformUsernameInput({
   inputId = 'platform-username-input',
   ariaLabel = 'Username',
   readOnly = false,
+  lockPlatform = false,
   previewSuggestionLabel,
   previewProfileImageUrl,
 }: Props) {
@@ -539,54 +542,69 @@ export function PlatformUsernameInput({
             </button>
           )}
         </div>
-        <Popover open={platformPopoverOpen} onOpenChange={setPlatformPopoverOpen}>
-          <PopoverTrigger asChild>
-            <button
-              type="button"
-              className="flex items-center gap-1.5 shrink-0 h-9 pl-2 pr-2 py-1 border-input text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors cursor-pointer"
-              aria-label="Choose platform"
-            >
-              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-muted dark:bg-muted/80 text-foreground">
-                {(() => {
-                  const Icon = currentPlatformOpt.icon;
-                  return <Icon className="h-4 w-4 shrink-0" />;
-                })()}
-              </span>
-              <ChevronDown
-                className={`h-4 w-4 shrink-0 transition-transform ${platformPopoverOpen ? 'rotate-180' : ''}`}
-                aria-hidden
-              />
-            </button>
-          </PopoverTrigger>
-          <PopoverContent className="w-72 p-2" align="end" sideOffset={4}>
-            <div className="space-y-0.5">
-              {PLATFORM_OPTIONS.map((opt) => {
-                const Icon = opt.icon;
-                const isDisabled = opt.disabled;
-                return (
-                  <button
-                    key={opt.value}
-                    type="button"
-                    disabled={isDisabled}
-                    title={isDisabled ? 'Temporarily unavailable' : undefined}
-                    onClick={() => {
-                      if (isDisabled) return;
-                      onPlatformChange(opt.value);
-                      setPlatformPopoverOpen(false);
-                    }}
-                    className={`w-full flex items-center justify-between gap-3 px-3 py-2.5 rounded-lg text-left transition-colors ${platform === opt.value ? 'bg-muted/40' : ''} ${isDisabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-muted/60'}`}
-                  >
-                    <div className="flex items-center gap-3">
-                      <Icon className="h-4 w-4 shrink-0" />
-                      <span className="font-medium">{opt.label}</span>
-                    </div>
-                    <span className="text-sm text-muted-foreground">{opt.hint}</span>
-                  </button>
-                );
-              })}
-            </div>
-          </PopoverContent>
-        </Popover>
+        {lockPlatform ? (
+          <div
+            className="flex items-center gap-1.5 shrink-0 h-9 pl-2 pr-3 py-1 border-input text-muted-foreground"
+            aria-label={currentPlatformOpt.label}
+          >
+            <span className="flex h-8 w-8 items-center justify-center rounded-full bg-muted dark:bg-muted/80 text-foreground">
+              {(() => {
+                const Icon = currentPlatformOpt.icon;
+                return <Icon className="h-4 w-4 shrink-0" />;
+              })()}
+            </span>
+            <span className="text-sm font-medium text-foreground">{currentPlatformOpt.label}</span>
+          </div>
+        ) : (
+          <Popover open={platformPopoverOpen} onOpenChange={setPlatformPopoverOpen}>
+            <PopoverTrigger asChild>
+              <button
+                type="button"
+                className="flex items-center gap-1.5 shrink-0 h-9 pl-2 pr-2 py-1 border-input text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors cursor-pointer"
+                aria-label="Choose platform"
+              >
+                <span className="flex h-8 w-8 items-center justify-center rounded-full bg-muted dark:bg-muted/80 text-foreground">
+                  {(() => {
+                    const Icon = currentPlatformOpt.icon;
+                    return <Icon className="h-4 w-4 shrink-0" />;
+                  })()}
+                </span>
+                <ChevronDown
+                  className={`h-4 w-4 shrink-0 transition-transform ${platformPopoverOpen ? 'rotate-180' : ''}`}
+                  aria-hidden
+                />
+              </button>
+            </PopoverTrigger>
+            <PopoverContent className="w-72 p-2" align="end" sideOffset={4}>
+              <div className="space-y-0.5">
+                {PLATFORM_OPTIONS.map((opt) => {
+                  const Icon = opt.icon;
+                  const isDisabled = opt.disabled;
+                  return (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      disabled={isDisabled}
+                      title={isDisabled ? 'Temporarily unavailable' : undefined}
+                      onClick={() => {
+                        if (isDisabled) return;
+                        onPlatformChange(opt.value);
+                        setPlatformPopoverOpen(false);
+                      }}
+                      className={`w-full flex items-center justify-between gap-3 px-3 py-2.5 rounded-lg text-left transition-colors ${platform === opt.value ? 'bg-muted/40' : ''} ${isDisabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-muted/60'}`}
+                    >
+                      <div className="flex items-center gap-3">
+                        <Icon className="h-4 w-4 shrink-0" />
+                        <span className="font-medium">{opt.label}</span>
+                      </div>
+                      <span className="text-sm text-muted-foreground">{opt.hint}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </PopoverContent>
+          </Popover>
+        )}
       </div>
 
       {showTwitterPreview && normalizedUsername && (

--- a/src/components/zksend/PlatformUsernameInput.tsx
+++ b/src/components/zksend/PlatformUsernameInput.tsx
@@ -34,8 +34,10 @@ import {
 import type { SendRecipientType } from './ZkSendPanel';
 
 const PREVIEW_DEBOUNCE_MS = 500;
-/** Twitter preview: 3s debounce to reduce Twitter API (twitterapi.io) usage when typing. */
+/** Twitter: wait this long before calling Edge/API (cache-only check is faster). */
 const TWITTER_PREVIEW_DEBOUNCE_MS = 3000;
+/** Twitter: quick Supabase cache lookup so known handles preview without waiting for API debounce. */
+const TWITTER_CACHE_DEBOUNCE_MS = 400;
 
 const PROFILE_LINK_CLASS =
   'truncate text-foreground underline decoration-muted-foreground/50 underline-offset-2 hover:decoration-foreground';
@@ -127,6 +129,7 @@ export function PlatformUsernameInput({
   const [twitchPreviewData, setTwitchPreviewData] = useState<TwitchUserPreview | null>(null);
   const [twitchPreviewError, setTwitchPreviewError] = useState<string | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const twitterCacheDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastRequestRef = useRef<string>('');
   const inFlightRequestRef = useRef<string>('');
   const twitchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -173,6 +176,10 @@ export function PlatformUsernameInput({
         clearTimeout(debounceRef.current);
         debounceRef.current = null;
       }
+      if (twitterCacheDebounceRef.current) {
+        clearTimeout(twitterCacheDebounceRef.current);
+        twitterCacheDebounceRef.current = null;
+      }
       return;
     }
 
@@ -190,20 +197,41 @@ export function PlatformUsernameInput({
       setPreviewStatus('success');
       setPreviewData(memoryStale);
       setPreviewError(null);
-    }
-
-    if (debounceRef.current) clearTimeout(debounceRef.current);
-    if (!memoryStale) {
+    } else {
       setPreviewStatus('loading');
       setPreviewError(null);
     }
 
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (twitterCacheDebounceRef.current) clearTimeout(twitterCacheDebounceRef.current);
+
+    let resolvedFromDb = Boolean(memoryStale?.profile_image_url);
+    const requested = normalizedUsername;
+    lastRequestRef.current = requested;
+
+    // Phase 1 (fast): Supabase cache only — no Twitter API.
+    twitterCacheDebounceRef.current = setTimeout(() => {
+      twitterCacheDebounceRef.current = null;
+      fetchTwitterUserPreview(requested, { cacheOnly: true })
+        .then((result) => {
+          if (lastRequestRef.current !== requested) return;
+          if (result.success) {
+            resolvedFromDb = true;
+            setTwitterMemoryCache(requested, result.data);
+            setPreviewStatus('success');
+            setPreviewData(result.data);
+            setPreviewError(null);
+          }
+        })
+        .catch(() => {});
+    }, TWITTER_CACHE_DEBOUNCE_MS);
+
+    // Phase 2 (slow): only if DB miss — may call Edge / Twitter API once.
     debounceRef.current = setTimeout(() => {
       debounceRef.current = null;
-      const requested = normalizedUsername;
+      if (resolvedFromDb || getFreshTwitterMemoryCache(requested)?.profile_image_url) return;
       if (inFlightRequestRef.current === requested) return;
       inFlightRequestRef.current = requested;
-      lastRequestRef.current = requested;
 
       fetchTwitterUserPreview(requested)
         .then((result) => {
@@ -213,7 +241,7 @@ export function PlatformUsernameInput({
             setPreviewStatus('success');
             setPreviewData(result.data);
             setPreviewError(null);
-          } else if (!memoryStale) {
+          } else if (!memoryStale && !resolvedFromDb) {
             setPreviewStatus('error');
             setPreviewData(null);
             setPreviewError(result.error);
@@ -228,6 +256,10 @@ export function PlatformUsernameInput({
       if (debounceRef.current) {
         clearTimeout(debounceRef.current);
         debounceRef.current = null;
+      }
+      if (twitterCacheDebounceRef.current) {
+        clearTimeout(twitterCacheDebounceRef.current);
+        twitterCacheDebounceRef.current = null;
       }
     };
   }, [showTwitterPreview, normalizedUsername]);

--- a/src/components/zksend/RemitSendForm.tsx
+++ b/src/components/zksend/RemitSendForm.tsx
@@ -1,0 +1,394 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useAccount, useChainId, useSwitchChain, useWalletClient } from 'wagmi';
+import { toast } from 'sonner';
+import {
+  ArrowRight,
+  CheckCircle2,
+  Copy,
+  CreditCard,
+  ExternalLink,
+  Globe2,
+  Landmark,
+  Loader2,
+  Send,
+  ShieldCheck,
+  Twitter,
+  WalletCards,
+} from 'lucide-react';
+
+import { useCircleWallet } from '@/hooks/useCircleWallet';
+import { usePrivySafe } from '@/lib/privy/usePrivySafe';
+import { ARC_CHAIN_ID, getExplorerTxUrl } from '@/lib/web3/constants';
+import { isSocialRecipientValid, normalizeSocialUsername } from '@/lib/reclaim/identity';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+import { getRemitQuote, REMIT_FEE_AED, REMIT_RATE_USDC_PER_AED } from './remitQuote';
+import { submitSocialZkSendPayment, type SocialPaymentOutcome } from './socialPaymentAction';
+import type { WalletSource } from './WalletSourceToggle';
+
+type FundingSource = 'circle' | 'external' | 'card';
+
+const DESTINATIONS = ['India', 'Philippines', 'Pakistan', 'Egypt', 'United Kingdom'] as const;
+
+function formatAed(value: string): string {
+  const number = Number(value || 0);
+  return Number.isFinite(number) ? number.toFixed(2) : '0.00';
+}
+
+function claimLink(username: string, paymentId: string | null): string {
+  const url = new URL('/payments', window.location.origin);
+  url.searchParams.set('tab', 'receive');
+  url.searchParams.set('platform', 'twitter');
+  url.searchParams.set('username', username);
+  if (paymentId) url.searchParams.set('paymentId', paymentId);
+  return url.toString();
+}
+
+export function RemitSendForm() {
+  const { address, isConnected } = useAccount();
+  const connectedChainId = useChainId();
+  const { data: walletClient } = useWalletClient();
+  const { switchChainAsync } = useSwitchChain();
+  const { developerWallet, hasDeveloperWallet } = useCircleWallet();
+  const { user: privyUser } = usePrivySafe();
+
+  const [aedAmount, setAedAmount] = useState('100');
+  const [username, setUsername] = useState('');
+  const [destination, setDestination] = useState<(typeof DESTINATIONS)[number]>('India');
+  const [fundingSource, setFundingSource] = useState<FundingSource>('external');
+  const [cardSettlementWallet, setCardSettlementWallet] = useState<WalletSource>('circle');
+  const [loading, setLoading] = useState(false);
+  const [outcome, setOutcome] = useState<SocialPaymentOutcome | null>(null);
+
+  useEffect(() => {
+    if (hasDeveloperWallet || fundingSource !== 'circle') return;
+    setFundingSource('external');
+  }, [fundingSource, hasDeveloperWallet]);
+
+  useEffect(() => {
+    if (hasDeveloperWallet || cardSettlementWallet !== 'circle') return;
+    setCardSettlementWallet('external');
+  }, [cardSettlementWallet, hasDeveloperWallet]);
+
+  const quote = useMemo(() => getRemitQuote(aedAmount), [aedAmount]);
+  const normalizedUsername = useMemo(() => normalizeSocialUsername(username.replace(/^@/, '')), [username]);
+  const usernameIsValid = isSocialRecipientValid('twitter', username);
+  const settlementWallet: WalletSource = fundingSource === 'card' ? cardSettlementWallet : fundingSource;
+  const externalReady = isConnected && !!address && !!walletClient && connectedChainId === ARC_CHAIN_ID;
+  const circleReady = hasDeveloperWallet && !!developerWallet;
+  const walletReady = settlementWallet === 'circle' ? circleReady : externalReady;
+  const showNetworkSwitch = settlementWallet === 'external' && isConnected && connectedChainId !== ARC_CHAIN_ID;
+  const canSubmit = quote.isValid && usernameIsValid && walletReady && !loading;
+
+  const handleSwitchNetwork = async () => {
+    try {
+      await switchChainAsync({ chainId: ARC_CHAIN_ID });
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Unable to switch to Arc Testnet');
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (showNetworkSwitch) {
+      await handleSwitchNetwork();
+      return;
+    }
+    if (!canSubmit || !normalizedUsername) return;
+    setLoading(true);
+    try {
+      const result = await submitSocialZkSendPayment({
+        amount: quote.recipientUsdc,
+        tokenType: 'USDC',
+        platform: 'twitter',
+        username: normalizedUsername,
+        walletSource: settlementWallet,
+        chainId: settlementWallet === 'circle' ? ARC_CHAIN_ID : connectedChainId,
+        isConnected,
+        address,
+        walletClient,
+        developerWallet,
+        hasDeveloperWallet,
+        privyUserId: privyUser?.id,
+        requireArc: true,
+      });
+      setOutcome(result);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to send remittance');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleCopyClaimLink = async () => {
+    if (!outcome) return;
+    try {
+      await navigator.clipboard.writeText(claimLink(outcome.normalizedUsername, outcome.paymentId));
+      toast.success('Claim link copied');
+    } catch {
+      toast.error('Unable to copy the claim link');
+    }
+  };
+
+  const reset = () => {
+    setOutcome(null);
+    setAedAmount('100');
+    setUsername('');
+    setDestination('India');
+  };
+
+  if (outcome) {
+    return (
+      <Card className="overflow-hidden border-emerald-100 bg-white/95 shadow-[0_24px_80px_-32px_rgba(16,185,129,0.45)]">
+        <CardContent className="space-y-7 p-6 sm:p-10">
+          <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-100 text-emerald-700">
+            <CheckCircle2 className="h-8 w-8" />
+          </div>
+          <div>
+            <p className="remit-kicker text-emerald-700">Arc testnet settlement confirmed</p>
+            <h2 className="remit-section-title mt-2 text-3xl text-slate-950">Payment sent</h2>
+            <p className="remit-lede mt-2 text-slate-600">
+              <span className="remit-quote-value">{formatAed(aedAmount)}</span> AED sent to @{outcome.normalizedUsername}.
+            </p>
+            <p className="mt-1 text-sm text-slate-500">The recipient can claim USDC after verifying Twitter/X ownership.</p>
+          </div>
+          <div className="grid gap-3 rounded-2xl bg-emerald-50/80 p-4 text-sm sm:grid-cols-3">
+            <div>
+              <p className="remit-label text-slate-500">Recipient gets</p>
+              <p className="remit-quote-value mt-1 text-base text-slate-950">{quote.recipientUsdc} USDC</p>
+            </div>
+            <div>
+              <p className="remit-label text-slate-500">Total wallet debit</p>
+              <p className="remit-quote-value mt-1 text-base text-slate-950">{outcome.totalDebitUsdc} USDC</p>
+            </div>
+            <div>
+              <p className="remit-label text-slate-500">Remittance fee</p>
+              <p className="remit-quote-value mt-1 text-base text-slate-950">{REMIT_FEE_AED.toFixed(2)} AED</p>
+            </div>
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <Button onClick={handleCopyClaimLink} className="flex-1 bg-slate-950 text-white hover:bg-slate-800"><Copy className="mr-2 h-4 w-4" />Copy claim link</Button>
+            {outcome.txHash ? <Button asChild variant="outline" className="flex-1"><a href={getExplorerTxUrl(outcome.chainId, outcome.txHash)} target="_blank" rel="noreferrer">View transaction<ExternalLink className="ml-2 h-4 w-4" /></a></Button> : null}
+          </div>
+          <Button variant="ghost" onClick={reset} className="w-full">Send another payment</Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="overflow-hidden border-white/90 bg-white/95 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.38)]">
+      <CardContent className="space-y-6 p-5 sm:p-8">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold text-emerald-800">
+              <Landmark className="h-3.5 w-3.5" />
+              UAE origin
+            </div>
+            <h2 className="remit-section-title mt-3 text-slate-950">Your remittance</h2>
+          </div>
+          <div className="flex items-center gap-2 text-sm font-medium text-slate-500">
+            <span className="rounded-full bg-slate-100 px-2.5 py-1">UAE</span>
+            <ArrowRight className="h-4 w-4" />
+            <Globe2 className="h-4 w-4 text-emerald-600" />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="remit-amount" className="remit-label">You send</Label>
+          <div className="flex overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm focus-within:ring-2 focus-within:ring-emerald-500/30">
+            <Input
+              id="remit-amount"
+              inputMode="decimal"
+              value={aedAmount}
+              onChange={(event) => setAedAmount(event.target.value)}
+              className="remit-amount-input h-13 border-0 shadow-none focus-visible:ring-0"
+              aria-label="Amount in AED"
+            />
+            <div className="remit-currency flex items-center bg-slate-50 px-4 text-slate-700">AED</div>
+          </div>
+          {!quote.isValid && aedAmount ? (
+            <p className="text-xs text-rose-600">Enter more than {REMIT_FEE_AED.toFixed(2)} AED to cover the remittance fee.</p>
+          ) : null}
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label className="remit-label">From</Label>
+            <div className="flex h-10 items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 text-sm font-medium text-slate-700">
+              UAE <span aria-hidden>AE</span>
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="destination-country" className="remit-label">Destination country</Label>
+            <Select value={destination} onValueChange={(value) => setDestination(value as typeof destination)}>
+              <SelectTrigger id="destination-country" className="h-10 rounded-xl">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {DESTINATIONS.map((country) => (
+                  <SelectItem key={country} value={country}>{country}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="remit-recipient" className="remit-label">Recipient</Label>
+          <div className="flex overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm focus-within:ring-2 focus-within:ring-emerald-500/30">
+            <div className="flex items-center px-3 text-slate-400">@</div>
+            <Input
+              id="remit-recipient"
+              value={username.replace(/^@/, '')}
+              onChange={(event) => setUsername(event.target.value)}
+              placeholder="twitter username"
+              className="h-11 border-0 shadow-none focus-visible:ring-0"
+            />
+            <div className="flex items-center gap-1 bg-slate-50 px-3 text-sm font-medium text-slate-700">
+              <Twitter className="h-4 w-4" />
+              Twitter / X
+            </div>
+          </div>
+          {username && !usernameIsValid ? (
+            <p className="text-xs text-rose-600">Enter a valid Twitter/X username.</p>
+          ) : null}
+        </div>
+
+        <div className="space-y-3">
+          <Label className="remit-label">Funding source</Label>
+          <div className="grid gap-2 sm:grid-cols-3">
+            {([
+              ['circle', 'Internal Wallet', WalletCards, circleReady],
+              ['external', 'External Wallet', WalletCards, isConnected],
+              ['card', 'UAE Bank Card', CreditCard, true],
+            ] as const).map(([value, label, Icon, available]) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => available && setFundingSource(value)}
+                disabled={!available}
+                className={`rounded-xl border p-3 text-left transition ${
+                  fundingSource === value
+                    ? 'border-emerald-500 bg-emerald-50 ring-1 ring-emerald-500'
+                    : 'border-slate-200 bg-white hover:border-slate-300'
+                } disabled:cursor-not-allowed disabled:opacity-45`}
+              >
+                <Icon className="h-4 w-4 text-emerald-700" />
+                <p className="remit-funding-label mt-2 text-slate-900">{label}</p>
+                <p className="mt-0.5 text-xs text-slate-500">
+                  {value === 'card' ? 'Demo' : available ? 'Available' : 'Unavailable'}
+                </p>
+              </button>
+            ))}
+          </div>
+          {fundingSource === 'card' ? (
+            <div className="space-y-3 rounded-2xl border border-amber-200 bg-amber-50/70 p-4">
+              <div className="flex items-start justify-between rounded-xl bg-gradient-to-br from-slate-900 to-slate-700 p-4 text-white">
+                <div>
+                  <p className="text-xs text-slate-300">VISA</p>
+                  <p className="mt-5 font-mono tracking-[0.18em]">**** 4242</p>
+                  <p className="mt-2 text-xs text-slate-300">LEO K.</p>
+                </div>
+                <span className="rounded-full bg-amber-300 px-2 py-1 text-xs font-semibold text-amber-950">Demo only</span>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="card-settlement-wallet" className="remit-label">Settle demo pay-in with</Label>
+                <Select value={cardSettlementWallet} onValueChange={(value) => setCardSettlementWallet(value as WalletSource)}>
+                  <SelectTrigger id="card-settlement-wallet" className="bg-white">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="circle" disabled={!circleReady}>Internal Wallet</SelectItem>
+                    <SelectItem value="external" disabled={!isConnected}>External Wallet</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <p className="text-xs leading-5 text-amber-900">
+                This card is a conceptual AED pay-in. No card is charged; the selected wallet supplies testnet USDC settlement.
+              </p>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="rounded-2xl bg-slate-950 p-5 text-white">
+          <div className="flex items-center justify-between">
+            <p className="remit-label text-slate-300">Recipient gets</p>
+            <ShieldCheck className="h-5 w-5 text-emerald-300" />
+          </div>
+          <p className="remit-quote-total mt-2">
+            {quote.recipientUsdc} <span className="remit-currency text-base text-slate-300">USDC</span>
+          </p>
+          <div className="mt-5 space-y-2.5 border-t border-white/10 pt-4 text-sm">
+            <div className="flex justify-between text-slate-300">
+              <span>FX rate</span>
+              <span className="remit-quote-value">1 AED = {REMIT_RATE_USDC_PER_AED} USDC</span>
+            </div>
+            <div className="flex justify-between text-slate-300">
+              <span>Remittance fee</span>
+              <span className="remit-quote-value">{REMIT_FEE_AED.toFixed(2)} AED</span>
+            </div>
+            <div className="flex justify-between text-slate-300">
+              <span>zkSend protocol fee</span>
+              <span className="remit-quote-value">{quote.protocolFeeUsdc} USDC</span>
+            </div>
+            <div className="flex justify-between font-semibold text-white">
+              <span>Total wallet debit</span>
+              <span className="remit-quote-value text-sm">{quote.totalDebitUsdc} USDC</span>
+            </div>
+            <div className="flex justify-between text-slate-400">
+              <span>Delivery target</span>
+              <span>Under 10 seconds</span>
+            </div>
+            <div className="flex justify-between text-slate-400">
+              <span>Identity</span>
+              {normalizedUsername ? (
+                <a
+                  href={`https://x.com/${normalizedUsername}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="remit-quote-value text-emerald-300 underline-offset-2 hover:text-emerald-200 hover:underline"
+                >
+                  twitter:@{normalizedUsername}
+                </a>
+              ) : (
+                <span className="remit-quote-value">twitter:@username</span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {showNetworkSwitch ? (
+          <Button onClick={handleSwitchNetwork} className="w-full bg-amber-500 text-amber-950 hover:bg-amber-400">
+            Switch to Arc Testnet
+          </Button>
+        ) : (
+          <Button onClick={handleSubmit} disabled={!canSubmit} className="w-full bg-emerald-600 text-white hover:bg-emerald-700">
+            {loading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Creating settlement...
+              </>
+            ) : (
+              <>
+                <Send className="mr-2 h-4 w-4" />
+                Send remittance
+              </>
+            )}
+          </Button>
+        )}
+        {!walletReady && !showNetworkSwitch ? (
+          <p className="text-center text-xs text-slate-500">
+            Connect an Arc wallet or create an Internal Wallet to complete settlement.
+          </p>
+        ) : null}
+        <p className="remit-disclaimer text-center text-slate-400">
+          Demo only: AED FX, destination corridors, and card funding are presentation concepts. Settlement uses USDC on Arc testnet.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/zksend/RemitSendForm.tsx
+++ b/src/components/zksend/RemitSendForm.tsx
@@ -12,7 +12,6 @@ import {
   Loader2,
   Send,
   ShieldCheck,
-  Twitter,
   WalletCards,
 } from 'lucide-react';
 
@@ -26,6 +25,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 
+import { PlatformUsernameInput } from './PlatformUsernameInput';
 import { getRemitQuote, REMIT_FEE_AED, REMIT_RATE_USDC_PER_AED } from './remitQuote';
 import { submitSocialZkSendPayment, type SocialPaymentOutcome } from './socialPaymentAction';
 import type { WalletSource } from './WalletSourceToggle';
@@ -237,26 +237,19 @@ export function RemitSendForm() {
           </div>
         </div>
 
-        <div className="space-y-2">
-          <Label htmlFor="remit-recipient" className="remit-label">Recipient</Label>
-          <div className="flex overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm focus-within:ring-2 focus-within:ring-emerald-500/30">
-            <div className="flex items-center px-3 text-slate-400">@</div>
-            <Input
-              id="remit-recipient"
-              value={username.replace(/^@/, '')}
-              onChange={(event) => setUsername(event.target.value)}
-              placeholder="twitter username"
-              className="h-11 border-0 shadow-none focus-visible:ring-0"
-            />
-            <div className="flex items-center gap-1 bg-slate-50 px-3 text-sm font-medium text-slate-700">
-              <Twitter className="h-4 w-4" />
-              Twitter / X
-            </div>
-          </div>
-          {username && !usernameIsValid ? (
-            <p className="text-xs text-rose-600">Enter a valid Twitter/X username.</p>
-          ) : null}
-        </div>
+        <PlatformUsernameInput
+          platform="twitter"
+          onPlatformChange={() => {}}
+          username={username}
+          onUsernameChange={setUsername}
+          label="Recipient"
+          inputId="remit-recipient"
+          ariaLabel="Twitter username"
+          lockPlatform
+        />
+        {username && !usernameIsValid ? (
+          <p className="text-xs text-rose-600">Enter a valid Twitter/X username.</p>
+        ) : null}
 
         <div className="space-y-3">
           <Label className="remit-label">Funding source</Label>
@@ -355,7 +348,7 @@ export function RemitSendForm() {
                   twitter:@{normalizedUsername}
                 </a>
               ) : (
-                <span className="remit-quote-value">twitter:@username</span>
+                <span className="remit-quote-value">social:@username</span>
               )}
             </div>
           </div>
@@ -385,9 +378,7 @@ export function RemitSendForm() {
             Connect an Arc wallet or create an Internal Wallet to complete settlement.
           </p>
         ) : null}
-        <p className="remit-disclaimer text-center text-slate-400">
-          Demo only: AED FX, destination corridors, and card funding are presentation concepts. Settlement uses USDC on Arc testnet.
-        </p>
+
       </CardContent>
     </Card>
   );

--- a/src/components/zksend/RemitSendForm.tsx
+++ b/src/components/zksend/RemitSendForm.tsx
@@ -142,7 +142,7 @@ export function RemitSendForm() {
 
   if (outcome) {
     return (
-      <Card className="overflow-hidden border-emerald-100 bg-white/95 shadow-[0_24px_80px_-32px_rgba(16,185,129,0.45)]">
+      <Card className="w-full min-w-0 overflow-hidden border-emerald-100 bg-white/95 shadow-[0_24px_80px_-32px_rgba(16,185,129,0.45)]">
         <CardContent className="space-y-7 p-6 sm:p-10">
           <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-emerald-100 text-emerald-700">
             <CheckCircle2 className="h-8 w-8" />
@@ -180,7 +180,7 @@ export function RemitSendForm() {
   }
 
   return (
-    <Card className="overflow-hidden border-white/90 bg-white/95 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.38)]">
+    <Card className="w-full min-w-0 overflow-hidden border-white/90 bg-white/95 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.38)]">
       <CardContent className="space-y-6 p-5 sm:p-8">
         <div className="flex items-start justify-between gap-4">
           <div>

--- a/src/components/zksend/SendPaymentForm.tsx
+++ b/src/components/zksend/SendPaymentForm.tsx
@@ -41,6 +41,7 @@ import {
 import { PlatformUsernameInput } from './PlatformUsernameInput';
 import { WalletSourceToggle } from './WalletSourceToggle';
 import { ZKSEND_SUCCESS_COPY, renderTransactionLink } from './transactionFeedback';
+import { submitSocialZkSendPayment } from './socialPaymentAction';
 
 import type { SendRecipientType } from './ZkSendPanel';
 import type { WalletSource } from './WalletSourceToggle';
@@ -206,6 +207,34 @@ export function SendPaymentForm({
   const onSubmit = async () => {
     try {
       setLastCreatedTxHash(null);
+
+      // Social payments share one action with the remit flow. Direct address sends
+      // remain on their existing path below.
+      if (platform !== 'address') {
+        setLoading(true);
+        const outcome = await submitSocialZkSendPayment({
+          amount,
+          tokenType,
+          platform,
+          username,
+          walletSource,
+          chainId: activeChainId,
+          isConnected,
+          address,
+          walletClient,
+          developerWallet,
+          hasDeveloperWallet,
+          privyUserId: privyUser?.id,
+        });
+        if (outcome.txHash) setLastCreatedTxHash(outcome.txHash);
+        toast.success(ZKSEND_SUCCESS_COPY.paymentCreated, {
+          description: outcome.txHash ? (
+            <span className="text-sm">TX: {renderTransactionLink(outcome.chainId, outcome.txHash)}</span>
+          ) : undefined,
+        });
+        return;
+      }
+
       const useCircle = walletSource === 'circle' && hasDeveloperWallet && developerWallet;
       if (useCircle) {
         if (!developerWallet || !amount || Number(amount) <= 0) throw new Error('Enter amount > 0');

--- a/src/components/zksend/ZkSendPanel.tsx
+++ b/src/components/zksend/ZkSendPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useChainId } from 'wagmi';
+import { useSearchParams } from 'react-router-dom';
 
 import { PendingPayments } from './PendingPayments';
 import { SendPaymentForm, type SendPaymentPreviewValues } from './SendPaymentForm';
@@ -28,15 +29,24 @@ function seedUsernameFromIdentity(username: string): string {
 }
 
 export function ZkSendPanel({ initialTab = 'send', preview = false, previewValues }: ZkSendPanelProps = {}) {
-  const [activeTab, setActiveTab] = useState<'send' | 'receive'>(initialTab);
+  const [searchParams] = useSearchParams();
+  const claimPlatform = searchParams.get('platform') === 'twitter' ? 'twitter' : null;
+  const claimUsername = claimPlatform ? searchParams.get('username')?.replace(/^@/, '') ?? '' : '';
+  const claimPaymentId = claimPlatform ? searchParams.get('paymentId') : null;
+  const claimTab = claimPlatform && claimUsername && searchParams.get('tab') === 'receive' ? 'receive' : null;
+  const [activeTab, setActiveTab] = useState<'send' | 'receive'>(claimTab ?? initialTab);
 
   // Send tab: always manual, never seeded from the connected identity.
   const [sendPlatform, setSendPlatform] = useState<SendRecipientType>(preview && previewValues ? previewValues.platform : 'twitter');
   const [sendUsername, setSendUsername] = useState(preview && previewValues ? previewValues.username : '');
 
   // Receive tab: auto-filled from the primary identity unless manually edited.
-  const [receivePlatform, setReceivePlatform] = useState<SendRecipientType>(preview && previewValues ? previewValues.platform : 'twitter');
-  const [receiveUsername, setReceiveUsername] = useState(preview && previewValues ? previewValues.username : '');
+  const [receivePlatform, setReceivePlatform] = useState<SendRecipientType>(
+    preview && previewValues ? previewValues.platform : claimPlatform ?? 'twitter'
+  );
+  const [receiveUsername, setReceiveUsername] = useState(
+    preview && previewValues ? previewValues.username : claimUsername
+  );
   const receiveEditedRef = useRef(false);
 
   const { identity } = useZkOAuthIdentity();
@@ -47,6 +57,14 @@ export function ZkSendPanel({ initialTab = 'send', preview = false, previewValue
   const isInternalWalletDisabled =
     activeChainId === BASE_SEPOLIA_CHAIN_ID || activeChainId === TEMPO_CHAIN_ID;
   const canUseInternalWallet = hasDeveloperWallet && !isInternalWalletDisabled;
+
+  useEffect(() => {
+    if (preview || !claimTab || !claimPlatform || !claimUsername) return;
+    receiveEditedRef.current = true;
+    setActiveTab('receive');
+    setReceivePlatform(claimPlatform);
+    setReceiveUsername(claimUsername);
+  }, [claimPlatform, claimTab, claimUsername, preview]);
 
   useEffect(() => {
     if (preview || !identity || receiveEditedRef.current) return;
@@ -129,6 +147,7 @@ export function ZkSendPanel({ initialTab = 'send', preview = false, previewValue
             onWalletSourceChange={setWalletSource}
             developerWallet={developerWallet}
             hasDeveloperWallet={canUseInternalWallet}
+            highlightPaymentId={claimPaymentId}
           />
         </TabsContent>
       </Tabs>

--- a/src/components/zksend/remitQuote.ts
+++ b/src/components/zksend/remitQuote.ts
@@ -1,0 +1,39 @@
+import { formatUsdcAmount, getZkSendFeeBreakdown } from './socialPaymentAction';
+
+export const REMIT_RATE_USDC_PER_AED = 0.2723;
+export const REMIT_FEE_AED = 1.5;
+
+export type RemitQuote = {
+  isValid: boolean;
+  aedAmount: string;
+  recipientUsdc: string;
+  protocolFeeUsdc: string;
+  totalDebitUsdc: string;
+};
+
+function parseAedCents(value: string): bigint | null {
+  const normalized = value.trim();
+  if (!/^\d+(?:\.\d{0,2})?$/.test(normalized)) return null;
+  const [whole, fraction = ''] = normalized.split('.');
+  return BigInt(whole) * 100n + BigInt(fraction.padEnd(2, '0'));
+}
+
+export function getRemitQuote(value: string): RemitQuote {
+  const aedCents = parseAedCents(value);
+  const feeCents = 150n;
+  if (aedCents === null || aedCents <= feeCents) {
+    return { isValid: false, aedAmount: value, recipientUsdc: '0', protocolFeeUsdc: '0', totalDebitUsdc: '0' };
+  }
+
+  // 1 AED = 0.2723 USDC. One AED cent therefore equals 2,723 USDC base units.
+  const recipientWei = (aedCents - feeCents) * 2723n;
+  const recipientUsdc = formatUsdcAmount(recipientWei);
+  const fees = getZkSendFeeBreakdown(recipientUsdc);
+  return {
+    isValid: true,
+    aedAmount: value,
+    recipientUsdc,
+    protocolFeeUsdc: fees.protocolFeeUsdc,
+    totalDebitUsdc: fees.totalDebitUsdc,
+  };
+}

--- a/src/components/zksend/socialPaymentAction.ts
+++ b/src/components/zksend/socialPaymentAction.ts
@@ -1,0 +1,239 @@
+import { createPublicClient, http, parseEventLogs } from 'viem';
+
+import web3Service from '@/lib/web3/web3Service';
+import {
+  generateSocialIdentityHash,
+  normalizeGmailAddress,
+  normalizeSocialPlatform,
+  normalizeSocialUsername,
+} from '@/lib/reclaim/identity';
+import { createZkSendPaymentRecord } from '@/lib/zksend/zksendPaymentsAPI';
+import { ARC_CHAIN_ID, ERC20ABI, getContractsForChain, ZkSendABI } from '@/lib/web3/constants';
+import { arcTestnet } from '@/lib/web3/wagmiConfig';
+import { DeveloperWalletService, type DeveloperWallet } from '@/lib/circle/developerWalletService';
+import { apiCall } from '@/lib/supabase/client';
+import { getCircleWalletPrivyUserIdForTx } from '@/hooks/useCircleWallet';
+
+import type { WalletSource } from './WalletSourceToggle';
+
+export type ZkSendSettlementToken = 'USDC' | 'EURC' | 'PATHUSD' | 'ALPHAUSD' | 'BETAUSD' | 'THETAUSD';
+
+const DECIMALS = 1_000_000n;
+const FEE_BPS = 10n;
+const BPS_DENOMINATOR = 10_000n;
+
+export type ZkSendFeeBreakdown = {
+  amountWei: bigint;
+  protocolFeeWei: bigint;
+  totalDebitWei: bigint;
+  protocolFeeUsdc: string;
+  totalDebitUsdc: string;
+};
+
+export type SocialPaymentOutcome = {
+  paymentId: string | null;
+  txHash: string | null;
+  chainId: number;
+  platform: string;
+  normalizedUsername: string;
+  recipientIdentityHash: `0x${string}`;
+  protocolFeeUsdc: string;
+  totalDebitUsdc: string;
+};
+
+type SubmitSocialPaymentInput = {
+  amount: string;
+  tokenType: ZkSendSettlementToken;
+  platform: string;
+  username: string;
+  walletSource: WalletSource;
+  chainId: number;
+  isConnected: boolean;
+  address?: string;
+  walletClient?: any;
+  developerWallet?: DeveloperWallet | null;
+  hasDeveloperWallet: boolean;
+  privyUserId?: string;
+  /** Remit uses Arc only; generic payments preserve their current selected-chain behaviour. */
+  requireArc?: boolean;
+};
+
+function parseUsdcAmount(amount: string): bigint {
+  const value = amount.trim();
+  if (!/^\d+(?:\.\d{0,6})?$/.test(value)) throw new Error('Enter a valid amount with up to 6 decimals');
+  const [whole, fraction = ''] = value.split('.');
+  return BigInt(whole) * DECIMALS + BigInt(fraction.padEnd(6, '0'));
+}
+
+export function formatUsdcAmount(value: bigint): string {
+  const whole = value / DECIMALS;
+  const fraction = (value % DECIMALS).toString().padStart(6, '0').replace(/0+$/, '');
+  return fraction ? `${whole}.${fraction}` : whole.toString();
+}
+
+export function getZkSendFeeBreakdown(amount: string): ZkSendFeeBreakdown {
+  const amountWei = parseUsdcAmount(amount);
+  const protocolFeeWei = (amountWei * FEE_BPS) / BPS_DENOMINATOR;
+  const totalDebitWei = amountWei + protocolFeeWei;
+  return {
+    amountWei,
+    protocolFeeWei,
+    totalDebitWei,
+    protocolFeeUsdc: formatUsdcAmount(protocolFeeWei),
+    totalDebitUsdc: formatUsdcAmount(totalDebitWei),
+  };
+}
+
+function normalizeRecipient(platform: string, username: string) {
+  const normalizedPlatform = normalizeSocialPlatform(platform);
+  const normalizedUsername = normalizedPlatform === 'gmail'
+    ? normalizeGmailAddress(username)
+    : normalizeSocialUsername(username.replace(/^@/, ''));
+  if (!normalizedPlatform) throw new Error('Unsupported platform');
+  if (!normalizedUsername) throw new Error('Enter recipient');
+  const recipientIdentityHash = generateSocialIdentityHash(normalizedPlatform, normalizedUsername);
+  if (!recipientIdentityHash) throw new Error('Invalid social identity');
+  return { normalizedPlatform, normalizedUsername, recipientIdentityHash };
+}
+
+async function pollTransactionStatus(transactionId: string): Promise<string> {
+  for (let attempt = 0; attempt < 30; attempt++) {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    const status = await apiCall(`/wallets/transaction-status?transactionId=${encodeURIComponent(transactionId)}`, {
+      method: 'GET',
+    }) as { transactionState?: string; txHash?: string; error?: string };
+    if (status.transactionState === 'FAILED') throw new Error(status.error ?? 'Transaction failed');
+    if (status.txHash) return status.txHash;
+  }
+  throw new Error('Transaction status timeout');
+}
+
+export async function submitSocialZkSendPayment(input: SubmitSocialPaymentInput): Promise<SocialPaymentOutcome> {
+  if (!input.amount || Number(input.amount) <= 0) throw new Error('Enter amount > 0');
+  if (input.requireArc && input.chainId !== ARC_CHAIN_ID) {
+    throw new Error('Switch your wallet to Arc Testnet to send this remittance');
+  }
+
+  const { normalizedPlatform, normalizedUsername, recipientIdentityHash } = normalizeRecipient(input.platform, input.username);
+  const fees = getZkSendFeeBreakdown(input.amount);
+  const contracts = getContractsForChain(input.chainId);
+  const useCircle = input.walletSource === 'circle' && input.hasDeveloperWallet && input.developerWallet;
+  let paymentId: string | null = null;
+  let txHash: string | null = null;
+
+  if (useCircle) {
+    const wallet = input.developerWallet!;
+    const tokenAddress = {
+      USDC: contracts.usdc,
+      EURC: contracts.eurc,
+      PATHUSD: contracts.pathusd,
+      ALPHAUSD: contracts.alphausd,
+      BETAUSD: contracts.betausd,
+      THETAUSD: contracts.thetausd,
+    }[input.tokenType];
+    if (!tokenAddress || !contracts.zksend) throw new Error('Arc USDC settlement is not configured');
+    const publicClient = createPublicClient({ chain: arcTestnet, transport: http() });
+    const balance = await publicClient.readContract({
+      address: tokenAddress as `0x${string}`,
+      abi: ERC20ABI,
+      functionName: 'balanceOf',
+      args: [wallet.wallet_address as `0x${string}`],
+    }) as bigint;
+    if (balance < fees.totalDebitWei) {
+      throw new Error(`Insufficient ${input.tokenType} balance. Required: ${fees.totalDebitUsdc}`);
+    }
+
+    const privyUserId = getCircleWalletPrivyUserIdForTx(wallet, input.address, input.privyUserId);
+    const approve = await DeveloperWalletService.sendTransaction({
+      walletId: wallet.circle_wallet_id,
+      walletAddress: wallet.wallet_address,
+      contractAddress: tokenAddress,
+      functionName: 'approve',
+      args: [contracts.zksend, fees.totalDebitWei],
+      blockchain: 'ARC-TESTNET',
+      privyUserId,
+      socialPlatform: wallet.social_platform ?? undefined,
+      socialUserId: wallet.social_user_id ?? undefined,
+    });
+    if (!approve.success) throw new Error(approve.error ?? 'Approve failed');
+    if (approve.transactionId) await pollTransactionStatus(approve.transactionId);
+
+    const create = await DeveloperWalletService.sendTransaction({
+      walletId: wallet.circle_wallet_id,
+      walletAddress: wallet.wallet_address,
+      contractAddress: contracts.zksend,
+      functionName: 'createPayment',
+      args: [recipientIdentityHash, normalizedPlatform, fees.amountWei, tokenAddress],
+      blockchain: 'ARC-TESTNET',
+      privyUserId,
+      socialPlatform: wallet.social_platform ?? undefined,
+      socialUserId: wallet.social_user_id ?? undefined,
+    });
+    if (!create.success) throw new Error(create.error ?? 'Create payment failed');
+    txHash = create.txHash ?? null;
+    if (!txHash && create.transactionId) txHash = await pollTransactionStatus(create.transactionId);
+
+    if (txHash) {
+      try {
+        const receipt = await publicClient.getTransactionReceipt({ hash: txHash as `0x${string}` });
+        const event = parseEventLogs({ abi: ZkSendABI, logs: receipt.logs, eventName: 'PaymentCreated' })[0] as {
+          args?: { paymentId?: bigint };
+        } | undefined;
+        paymentId = event?.args?.paymentId?.toString() ?? null;
+      } catch {
+        // A successful Circle transaction can be indexed later if receipt parsing is delayed.
+      }
+    }
+
+    if (paymentId) {
+      await createZkSendPaymentRecord({
+        paymentId,
+        senderAddress: wallet.wallet_address,
+        recipientIdentityHash,
+        platform: normalizedPlatform,
+        recipientUsername: input.username,
+        amount: input.amount,
+        currency: input.tokenType,
+        txHash: txHash ?? undefined,
+        chainId: ARC_CHAIN_ID,
+        contractAddress: contracts.zksend,
+      }).catch((error) => console.warn('[zkSEND] Failed to store payment in DB:', error));
+    }
+  } else {
+    if (!input.isConnected || !input.address || !input.walletClient) throw new Error('Connect wallet to send');
+    await web3Service.initialize(input.walletClient, input.address, input.chainId);
+    const result = await web3Service.createZkSendPayment({
+      socialIdentityHash: recipientIdentityHash,
+      platform: normalizedPlatform,
+      amount: input.amount,
+      tokenType: input.tokenType,
+    });
+    paymentId = result.paymentId;
+    txHash = result.txHash;
+    if (paymentId) {
+      await createZkSendPaymentRecord({
+        paymentId,
+        senderAddress: input.address,
+        recipientIdentityHash,
+        platform: normalizedPlatform,
+        recipientUsername: input.username,
+        amount: input.amount,
+        currency: input.tokenType,
+        txHash: txHash ?? undefined,
+        chainId: input.chainId,
+        contractAddress: contracts.zksend,
+      }).catch((error) => console.warn('[zkSEND] Failed to store payment in DB:', error));
+    }
+  }
+
+  return {
+    paymentId,
+    txHash,
+    chainId: input.requireArc ? ARC_CHAIN_ID : input.chainId,
+    platform: normalizedPlatform,
+    normalizedUsername,
+    recipientIdentityHash,
+    protocolFeeUsdc: fees.protocolFeeUsdc,
+    totalDebitUsdc: fees.totalDebitUsdc,
+  };
+}

--- a/src/lib/twitter/userLookup.ts
+++ b/src/lib/twitter/userLookup.ts
@@ -1,7 +1,7 @@
 /**
  * Twitter/X user lookup for handle input preview (avatar + name).
- * First checks Supabase cache (twitter_user_cache) to avoid hitting Twitter API;
- * only calls zk-sender Edge Function GET /zk-sender/twitter/user on cache miss or stale cache.
+ * Prefer Supabase `twitter_user_cache`. Never call Twitter API when the DB
+ * already has a profile_image_url (unless explicit refresh / skipCache).
  */
 
 import { getApiUrl, supabase } from '@/lib/supabase/client';
@@ -9,12 +9,7 @@ import { publicAnonKey } from '@/lib/supabase/info';
 
 const TWITTER_USER_CACHE_TABLE = 'twitter_user_cache';
 
-/**
- * Soft TTL for proactive revalidation.
- * Keep this aligned with backend TWITTER_USER_CACHE_DAYS (7d) so we do not
- * burn twitterapi.io credits on every revisit - avatar URL 404 still triggers
- * a one-shot refresh when the profile picture actually changed.
- */
+/** Memory / soft TTL for in-app preview cache (does not force Twitter API). */
 export const TWITTER_CACHE_SOFT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 export interface TwitterUserPreview {
@@ -65,13 +60,6 @@ export function upgradeTwitterAvatarUrl(url: string): string | null {
   return null;
 }
 
-function isCacheFresh(updatedAt: string | null | undefined, now = Date.now()): boolean {
-  if (!updatedAt) return false;
-  const ts = Date.parse(updatedAt);
-  if (!Number.isFinite(ts)) return false;
-  return now - ts < TWITTER_CACHE_SOFT_TTL_MS;
-}
-
 function previewFromRow(row: {
   username: string;
   name?: string | null;
@@ -84,6 +72,21 @@ function previewFromRow(row: {
     profile_image_url: row.profile_image_url ?? null,
     updated_at: row.updated_at ?? null,
   };
+}
+
+async function readTwitterUserCache(normalized: string): Promise<TwitterUserPreview | null> {
+  try {
+    const { data: row, error: dbError } = await supabase
+      .from(TWITTER_USER_CACHE_TABLE)
+      .select('username, name, profile_image_url, updated_at')
+      .ilike('username', normalized)
+      .maybeSingle();
+
+    if (dbError || !row?.username) return null;
+    return previewFromRow(row);
+  } catch {
+    return null;
+  }
 }
 
 async function fetchTwitterUserFromEdge(
@@ -138,12 +141,19 @@ export interface FetchTwitterUserPreviewOptions {
   skipCache?: boolean;
   /** Append refresh=1 so backend force-refreshes from Twitter API. */
   refresh?: boolean;
+  /**
+   * Only read Supabase cache — never call Edge / Twitter API.
+   * Returns CACHE_MISS when the row is absent (or has no avatar when requireImage is true).
+   */
+  cacheOnly?: boolean;
+  /** With cacheOnly, treat a row without profile_image_url as a miss. Default true. */
+  requireImage?: boolean;
 }
 
 /**
  * Fetch Twitter user profile by username for preview.
- * Fresh cache (< soft TTL) returns immediately. Stale cache triggers Edge refresh;
- * if refresh fails, stale cache is returned so the UI still works.
+ * If `twitter_user_cache` already has profile_image_url → return it and do not call Twitter API.
+ * API is used only on cache miss (or explicit refresh / skipCache).
  */
 export async function fetchTwitterUserPreview(
   username: string,
@@ -155,36 +165,23 @@ export async function fetchTwitterUserPreview(
   }
 
   const forceRefresh = options?.skipCache === true || options?.refresh === true;
-
-  let stale: TwitterUserPreview | null = null;
+  const requireImage = options?.requireImage !== false;
 
   if (!forceRefresh) {
-    try {
-      const { data: row, error: dbError } = await supabase
-        .from(TWITTER_USER_CACHE_TABLE)
-        .select('username, name, profile_image_url, updated_at')
-        .ilike('username', normalized)
-        .maybeSingle();
-
-      if (!dbError && row?.username) {
-        const preview = previewFromRow(row);
-        if (isCacheFresh(row.updated_at)) {
-          return { success: true, fromCache: true, data: preview };
-        }
-        stale = preview;
+    const cached = await readTwitterUserCache(normalized);
+    if (cached) {
+      const hasImage = Boolean(cached.profile_image_url);
+      if (hasImage || !requireImage) {
+        return { success: true, fromCache: true, data: cached };
       }
-    } catch {
-      // Supabase unavailable or table missing: fall through to Edge Function
+      if (options?.cacheOnly) {
+        return { success: false, error: 'Not in cache', code: 'CACHE_MISS' };
+      }
+      // Row without image: fall through to Edge once to populate avatar.
+    } else if (options?.cacheOnly) {
+      return { success: false, error: 'Not in cache', code: 'CACHE_MISS' };
     }
   }
 
-  const edge = await fetchTwitterUserFromEdge(normalized, forceRefresh || Boolean(stale));
-  if (edge.success) return edge;
-
-  // Keep serving stale cache when live refresh fails (broken API / rate limit).
-  if (stale) {
-    return { success: true, fromCache: true, data: stale };
-  }
-
-  return edge;
+  return fetchTwitterUserFromEdge(normalized, forceRefresh);
 }

--- a/src/lib/twitter/userLookup.ts
+++ b/src/lib/twitter/userLookup.ts
@@ -1,7 +1,7 @@
 /**
  * Twitter/X user lookup for handle input preview (avatar + name).
  * First checks Supabase cache (twitter_user_cache) to avoid hitting Twitter API;
- * only calls zk-sender Edge Function GET /zk-sender/twitter/user on cache miss.
+ * only calls zk-sender Edge Function GET /zk-sender/twitter/user on cache miss or stale cache.
  */
 
 import { getApiUrl, supabase } from '@/lib/supabase/client';
@@ -9,15 +9,27 @@ import { publicAnonKey } from '@/lib/supabase/info';
 
 const TWITTER_USER_CACHE_TABLE = 'twitter_user_cache';
 
+/**
+ * Soft TTL for proactive revalidation.
+ * Keep this aligned with backend TWITTER_USER_CACHE_DAYS (7d) so we do not
+ * burn twitterapi.io credits on every revisit - avatar URL 404 still triggers
+ * a one-shot refresh when the profile picture actually changed.
+ */
+export const TWITTER_CACHE_SOFT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
 export interface TwitterUserPreview {
   username: string;
   name: string;
   profile_image_url: string | null;
+  /** Cache timestamp from DB when available (ISO). */
+  updated_at?: string | null;
 }
 
 export interface TwitterUserLookupResult {
   success: true;
   data: TwitterUserPreview;
+  /** True when returned from cache without a live API refresh. */
+  fromCache?: boolean;
 }
 
 export interface TwitterUserLookupError {
@@ -43,60 +55,44 @@ export function normalizeTwitterHandle(handle: string): string {
   return handle.trim().replace(/^@/, '');
 }
 
-export interface FetchTwitterUserPreviewOptions {
-  /** Skip Supabase cache and always call Edge Function. Use when image returned 404 to get fresh profile_image_url. */
-  skipCache?: boolean;
-  /** Append refresh=1 so backend can force-refresh cache (e.g. after avatar 404). */
-  refresh?: boolean;
+/**
+ * Twitter CDN often serves `_normal` avatars that 404 after profile changes.
+ * Try the next larger variant before giving up on the cached URL.
+ */
+export function upgradeTwitterAvatarUrl(url: string): string | null {
+  if (url.includes('_normal.')) return url.replace('_normal.', '_bigger.');
+  if (url.includes('_bigger.')) return url.replace('_bigger.', '_400x400.');
+  return null;
 }
 
-/**
- * Fetch Twitter user profile by username for preview.
- * First looks up Supabase cache to avoid calling Twitter API; only calls Edge Function on cache miss.
- * Use options.skipCache (e.g. when profile image returned 404) to get fresh data from API.
- * Returns result with success/error for UI to show avatar, name, or error message.
- */
-export async function fetchTwitterUserPreview(
-  username: string,
-  options?: FetchTwitterUserPreviewOptions
+function isCacheFresh(updatedAt: string | null | undefined, now = Date.now()): boolean {
+  if (!updatedAt) return false;
+  const ts = Date.parse(updatedAt);
+  if (!Number.isFinite(ts)) return false;
+  return now - ts < TWITTER_CACHE_SOFT_TTL_MS;
+}
+
+function previewFromRow(row: {
+  username: string;
+  name?: string | null;
+  profile_image_url?: string | null;
+  updated_at?: string | null;
+}): TwitterUserPreview {
+  return {
+    username: row.username,
+    name: row.name ?? row.username,
+    profile_image_url: row.profile_image_url ?? null,
+    updated_at: row.updated_at ?? null,
+  };
+}
+
+async function fetchTwitterUserFromEdge(
+  normalized: string,
+  refresh: boolean
 ): Promise<TwitterUserLookupResponse> {
-  const normalized = normalizeTwitterHandle(username);
-  if (!normalized) {
-    return { success: false, error: 'Enter a username', code: 'MISSING_USERNAME' };
-  }
-
-  const skipCache = options?.skipCache === true || options?.refresh === true;
-
-  // 1. Check Supabase cache unless skipCache (e.g. after image 404)
-  if (!skipCache) {
-    try {
-      const { data: row, error: dbError } = await supabase
-        .from(TWITTER_USER_CACHE_TABLE)
-        .select('username, name, profile_image_url')
-        .ilike('username', normalized)
-        .maybeSingle();
-
-      if (!dbError && row?.username) {
-        return {
-          success: true,
-          data: {
-            username: row.username,
-            name: row.name ?? row.username,
-            profile_image_url: row.profile_image_url ?? null,
-          },
-        };
-      }
-    } catch {
-      // Supabase unavailable or table missing: fall through to Edge Function
-    }
-  }
-
-  // 2. Cache miss or skipCache: call zk-sender Edge Function (refresh=1 asks backend to refresh cache if supported)
   const base = getTwitterLookupBaseUrl().replace(/\/$/, '');
   let url = `${base}/zk-sender/twitter/user?username=${encodeURIComponent(normalized)}`;
-  if (skipCache || options?.refresh === true) {
-    url += '&refresh=1';
-  }
+  if (refresh) url += '&refresh=1';
 
   try {
     const res = await fetch(url, {
@@ -108,10 +104,12 @@ export async function fetchTwitterUserPreview(
     if (res.ok && body.username) {
       return {
         success: true,
+        fromCache: Boolean(body.from_cache),
         data: {
           username: body.username,
           name: body.name ?? body.username,
           profile_image_url: body.profile_image_url ?? null,
+          updated_at: body.updated_at ?? new Date().toISOString(),
         },
       };
     }
@@ -133,4 +131,60 @@ export async function fetchTwitterUserPreview(
     const message = err instanceof Error ? err.message : 'Request failed';
     return { success: false, error: message, code: 'NETWORK_ERROR' };
   }
+}
+
+export interface FetchTwitterUserPreviewOptions {
+  /** Skip Supabase cache and always call Edge Function. Use when image returned 404 to get fresh profile_image_url. */
+  skipCache?: boolean;
+  /** Append refresh=1 so backend force-refreshes from Twitter API. */
+  refresh?: boolean;
+}
+
+/**
+ * Fetch Twitter user profile by username for preview.
+ * Fresh cache (< soft TTL) returns immediately. Stale cache triggers Edge refresh;
+ * if refresh fails, stale cache is returned so the UI still works.
+ */
+export async function fetchTwitterUserPreview(
+  username: string,
+  options?: FetchTwitterUserPreviewOptions
+): Promise<TwitterUserLookupResponse> {
+  const normalized = normalizeTwitterHandle(username);
+  if (!normalized) {
+    return { success: false, error: 'Enter a username', code: 'MISSING_USERNAME' };
+  }
+
+  const forceRefresh = options?.skipCache === true || options?.refresh === true;
+
+  let stale: TwitterUserPreview | null = null;
+
+  if (!forceRefresh) {
+    try {
+      const { data: row, error: dbError } = await supabase
+        .from(TWITTER_USER_CACHE_TABLE)
+        .select('username, name, profile_image_url, updated_at')
+        .ilike('username', normalized)
+        .maybeSingle();
+
+      if (!dbError && row?.username) {
+        const preview = previewFromRow(row);
+        if (isCacheFresh(row.updated_at)) {
+          return { success: true, fromCache: true, data: preview };
+        }
+        stale = preview;
+      }
+    } catch {
+      // Supabase unavailable or table missing: fall through to Edge Function
+    }
+  }
+
+  const edge = await fetchTwitterUserFromEdge(normalized, forceRefresh || Boolean(stale));
+  if (edge.success) return edge;
+
+  // Keep serving stale cache when live refresh fails (broken API / rate limit).
+  if (stale) {
+    return { success: true, fromCache: true, data: stale };
+  }
+
+  return edge;
 }

--- a/src/pages/Layout.tsx
+++ b/src/pages/Layout.tsx
@@ -161,6 +161,16 @@ export function Layout({ children }: LayoutProps) {
                 Payments
               </Link>
             ) : null}
+            <Link
+              to="/remit"
+              className={`px-4 py-2 rounded-2xl transition-[transform,background-color,color,box-shadow] duration-200 ease-[var(--ease-out)] active:scale-[0.97] flex items-center gap-2 font-semibold motion-reduce:transition-none motion-reduce:active:scale-100 ${
+                isActive('/remit')
+                  ? 'bg-emerald-600 text-white shadow-sm'
+                  : 'bg-emerald-50 border border-emerald-200 text-emerald-800 hover:bg-emerald-100'
+              }`}
+            >
+              Ignyte
+            </Link>
             <ConnectButton />
           </div>
         </div>

--- a/src/pages/RemitRoute.tsx
+++ b/src/pages/RemitRoute.tsx
@@ -4,7 +4,7 @@ import { RemitSendForm } from '@/components/zksend/RemitSendForm';
 export function RemitRoute() {
   return (
     <Layout>
-      <main className="remit-shell mx-auto max-w-2xl py-3 sm:py-8">
+      <main className="remit-shell w-full min-w-0 py-3 sm:py-8">
         <div className="mb-7 text-center">
           <p className="remit-kicker text-emerald-700">Sendly Remit</p>
           <h1 className="remit-title mt-2 text-slate-950">UAE to Global Remittance</h1>

--- a/src/pages/RemitRoute.tsx
+++ b/src/pages/RemitRoute.tsx
@@ -1,0 +1,19 @@
+import { Layout } from '@/pages/Layout';
+import { RemitSendForm } from '@/components/zksend/RemitSendForm';
+
+export function RemitRoute() {
+  return (
+    <Layout>
+      <main className="remit-shell mx-auto max-w-2xl py-3 sm:py-8">
+        <div className="mb-7 text-center">
+          <p className="remit-kicker text-emerald-700">Sendly Remit</p>
+          <h1 className="remit-title mt-2 text-slate-950">UAE to Global Remittance</h1>
+          <p className="remit-lede mx-auto mt-3 text-slate-600">
+            Send money to a verified @twitter username. No wallet address required.
+          </p>
+        </div>
+        <RemitSendForm />
+      </main>
+    </Layout>
+  );
+}

--- a/src/pages/RemitRoute.tsx
+++ b/src/pages/RemitRoute.tsx
@@ -9,7 +9,7 @@ export function RemitRoute() {
           <p className="remit-kicker text-emerald-700">Sendly Remit</p>
           <h1 className="remit-title mt-2 text-slate-950">UAE to Global Remittance</h1>
           <p className="remit-lede mx-auto mt-3 text-slate-600">
-            Send money to a verified @twitter username. No wallet address required.
+            Send money to a verified social username.
           </p>
         </div>
         <RemitSendForm />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -268,6 +268,116 @@
   padding-bottom: 12px;
 }
 
+/* Remit page typography (/remit) - Space Grotesk display + Inter UI + JetBrains Mono figures */
+.remit-shell {
+  --remit-font-display: 'Space Grotesk', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --remit-font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --remit-font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-family: var(--remit-font-body);
+  font-optical-sizing: auto;
+  font-kerning: normal;
+}
+
+.remit-shell .remit-kicker {
+  font-family: var(--remit-font-display);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.remit-shell .remit-title {
+  font-family: var(--remit-font-display);
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.12;
+  text-wrap: balance;
+}
+
+@media (min-width: 640px) {
+  .remit-shell .remit-title {
+    font-size: 2.375rem;
+  }
+}
+
+.remit-shell .remit-lede {
+  font-family: var(--remit-font-body);
+  font-size: 1.0625rem;
+  font-weight: 400;
+  letter-spacing: -0.01em;
+  line-height: 1.55;
+  text-wrap: pretty;
+  max-width: 36rem;
+}
+
+.remit-shell .remit-section-title {
+  font-family: var(--remit-font-display);
+  font-size: 1.375rem;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  line-height: 1.2;
+  text-wrap: balance;
+}
+
+.remit-shell .remit-label {
+  font-family: var(--remit-font-body);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  line-height: 1.3;
+}
+
+.remit-shell .remit-amount-input {
+  font-family: var(--remit-font-mono);
+  font-size: 1.75rem;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+}
+
+.remit-shell .remit-currency {
+  font-family: var(--remit-font-display);
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.remit-shell .remit-quote-total {
+  font-family: var(--remit-font-mono);
+  font-size: 1.875rem;
+  font-weight: 500;
+  letter-spacing: -0.03em;
+  font-variant-numeric: tabular-nums;
+  line-height: 1.15;
+}
+
+.remit-shell .remit-quote-value {
+  font-family: var(--remit-font-mono);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+}
+
+.remit-shell .remit-funding-label {
+  font-family: var(--remit-font-display);
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+
+.remit-shell .remit-disclaimer {
+  font-family: var(--remit-font-body);
+  font-size: 0.6875rem;
+  font-weight: 400;
+  letter-spacing: 0.01em;
+  line-height: 1.45;
+  text-wrap: pretty;
+}
+
 /* Blog listing typography (/blog) */
 .blog-shell .blog-index-typography h1 {
   font-family: 'Space Grotesk', 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -105,9 +105,9 @@ export default defineConfig(({ mode }) => {
 
   const zktlsTarget = env.VITE_ZKTLS_PROXY_TARGET || 'http://localhost:3002';
   const server: Record<string, unknown> = {
-    port: 3001,
+    port: 3000,
     host: true,
-    open: useHttps ? 'https://localhost:3001' : true,
+    open: useHttps ? 'https://localhost:3000' : true,
     strictPort: true,
     proxy: {
       '/api': {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Refactors social payment creation into a shared module used by both `/payments` and `/remit`, touching Circle and on-chain zkSEND flows; remit is demo FX/card UI only but real wallet debits still occur on testnet.
> 
> **Overview**
> Adds **Sendly Remit / Ignyte** at `/remit`: a UAE-to-global remittance-style flow that still settles USDC on Arc via the existing **zkSEND** path—no new contract or backend rail.
> 
> **Remit product:** `RemitSendForm` collects AED amounts (demo FX in `remitQuote.ts`), locks recipients to **Twitter/X** (`lockPlatform` on `PlatformUsernameInput`), shows destination country and a **demo UAE bank card** pay-in (visual only; real debit from Circle or external wallet). Success surfaces a **claim link** to `/payments?tab=receive` with platform, username, and optional `paymentId`.
> 
> **Shared settlement:** New `submitSocialZkSendPayment` in `socialPaymentAction.ts` centralizes social zkSEND for Circle (approve + `createPayment`) and browser wallets; `/payments` social sends in `SendPaymentForm` now call it. Receive tab reads claim query params and **highlights** the matching pending payment.
> 
> **Twitter UX / API:** `userLookup` prefers Supabase cache, adds `cacheOnly` / `refresh`, and `upgradeTwitterAvatarUrl`; preview inputs use staged cache-then-API debounce and gentler avatar error recovery (`referrerPolicy="no-referrer"`).
> 
> **Docs & nav:** `Architecture.md` documents Remit; new `OpenSpec-Traceability.md` maps specs to repos; header **Ignyte** link; dev server port **3000**; minor shell layout tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 269483a7d2776a6602cbcc9dd4b6f5432f8d5d90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->